### PR TITLE
chore: add RainlangSourceMeta type alias

### DIFF
--- a/crates/cli/src/meta/mod.rs
+++ b/crates/cli/src/meta/mod.rs
@@ -72,6 +72,8 @@ pub enum ContentType {
     Cbor,
     #[serde(rename = "application/octet-stream")]
     OctetStream,
+    #[serde(rename = "text/plain")]
+    Text,
 }
 
 /// Content encoding of a cbor meta map

--- a/crates/cli/src/meta/mod.rs
+++ b/crates/cli/src/meta/mod.rs
@@ -72,8 +72,6 @@ pub enum ContentType {
     Cbor,
     #[serde(rename = "application/octet-stream")]
     OctetStream,
-    #[serde(rename = "text/plain")]
-    Text,
 }
 
 /// Content encoding of a cbor meta map

--- a/crates/cli/src/meta/types/mod.rs
+++ b/crates/cli/src/meta/types/mod.rs
@@ -1,10 +1,11 @@
 //! All the known different Rain meta types and implementations
 
-pub mod op;
+pub mod authoring;
 pub mod common;
 pub mod dotrain;
-pub mod rainlang;
-pub mod authoring;
-pub mod solidity_abi;
-pub mod interpreter_caller;
 pub mod expression_deployer_v2_bytecode;
+pub mod interpreter_caller;
+pub mod op;
+pub mod rainlang;
+pub mod rainlangsource;
+pub mod solidity_abi;

--- a/crates/cli/src/meta/types/rainlangsource/mod.rs
+++ b/crates/cli/src/meta/types/rainlangsource/mod.rs
@@ -1,0 +1,2 @@
+/// RainlangSource V1 meta implementations
+pub mod v1;

--- a/crates/cli/src/meta/types/rainlangsource/v1.rs
+++ b/crates/cli/src/meta/types/rainlangsource/v1.rs
@@ -1,0 +1,2 @@
+/// RainlangSource meta
+pub type RainlangSourceMeta = String;


### PR DESCRIPTION
- Add a type alias for `RainlangSourceMeta`

Missed this in #18 