### PR TITLE
Fix cargo fmt

### DIFF
--- a/crates/cli/src/meta/types/common/v1.rs
+++ b/crates/cli/src/meta/types/common/v1.rs
@@ -186,22 +186,8 @@ mod test {
     fn test_solidity_identifier_validate() {
         // valids
         for i in [
-            "A",
-            "AA",
-            "A0",
-            "Raindex",
-            "$",
-            "$$",
-            "_",
-            "__",
-            "a",
-            "aa",
-            "a_",
-            "A_",
-            "a$",
-            "A",
-            "A$",
-            "a0",
+            "A", "AA", "A0", "Raindex", "$", "$$", "_", "__", "a", "aa", "a_", "A_", "a$", "A",
+            "A$", "a0",
         ] {
             assert!(
                 SolidityIdentifier {


### PR DESCRIPTION
Fixes formatting issue from #101 — `cargo fmt` collapsed the array to inline style after the shorter string.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test data formatting for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->