### PR TITLE
Update rainix flake input owner to rainlanguage

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -252,13 +252,13 @@
       "locked": {
         "lastModified": 1777286590,
         "narHash": "sha256-7acpPP6U4ik7t6nF2e6dgcloMQSxUbD5sgfmIttC+Yw=",
-        "owner": "rainprotocol",
+        "owner": "rainlanguage",
         "repo": "rainix",
         "rev": "9cff7fcb2a674bb0d6a3b607e47a58992d2e4c96",
         "type": "github"
       },
       "original": {
-        "owner": "rainprotocol",
+        "owner": "rainlanguage",
         "repo": "rainix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Flake for development workflows.";
 
   inputs = {
-    rainix.url = "github:rainprotocol/rainix";
+    rainix.url = "github:rainlanguage/rainix";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
## Summary
- `rainprotocol` org was renamed to `rainlanguage`. URL still works via GitHub redirect but pin the canonical owner.
- Same rainix rev (`9cff7fc`), no behavioral change.

## Test plan
- [ ] CI green (Rainix CI + Subgraph CI)
- [ ] `nix develop` succeeds locally on the new owner

🤖 Generated with [Claude Code](https://claude.com/claude-code)