### PR TITLE
Bump GHA actions to Node 24 versions

### DIFF
--- a/.github/workflows/manual-rs-release.yml
+++ b/.github/workflows/manual-rs-release.yml
@@ -5,7 +5,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: recursive
@@ -16,7 +16,7 @@ jobs:
             keep-env-derivations = true
             keep-outputs = true
       - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
+        uses: nix-community/cache-nix-action@v7
         with:
           # restore and save a cache using this key
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}

--- a/.github/workflows/manual-sol-artifacts.yml
+++ b/.github/workflows/manual-sol-artifacts.yml
@@ -7,7 +7,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -18,7 +18,7 @@ jobs:
             keep-env-derivations = true
             keep-outputs = true
       - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
+        uses: nix-community/cache-nix-action@v7
         with:
           # restore and save a cache using this key
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}

--- a/.github/workflows/manual-subgraph-deploy.yml
+++ b/.github/workflows/manual-subgraph-deploy.yml
@@ -7,7 +7,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: recursive
@@ -18,7 +18,7 @@ jobs:
             keep-env-derivations = true
             keep-outputs = true
       - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
+        uses: nix-community/cache-nix-action@v7
         with:
           # restore and save a cache using this key
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -26,7 +26,7 @@ jobs:
     env:
       DEPLOYMENT_KEY: ${{ github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: recursive
@@ -37,7 +37,7 @@ jobs:
             keep-env-derivations = true
             keep-outputs = true
       - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
+        uses: nix-community/cache-nix-action@v7
         with:
           # restore and save a cache using this key
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}

--- a/.github/workflows/subgraph-test.yaml
+++ b/.github/workflows/subgraph-test.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: recursive
@@ -22,7 +22,7 @@ jobs:
             keep-env-derivations = true
             keep-outputs = true
       - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
+        uses: nix-community/cache-nix-action@v7
         with:
           # restore and save a cache using this key
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout@v4` -> `@v6` (uses `node24`)
- Bumps `nix-community/cache-nix-action@v6` -> `@v7` (uses `node24`)
- Applied across all 5 workflow files: `rainix.yaml`, `subgraph-test.yaml`, `manual-rs-release.yml`, `manual-sol-artifacts.yml`, `manual-subgraph-deploy.yml`

GitHub deprecation deadlines: forced Node 24 switch on **2026-06-02**, Node 20 removed from runners **2026-09-16**.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Test plan
- [ ] CI green on this branch (Rainix CI + Subgraph CI)
- [ ] Manual workflows still launch (smoke-test by triggering one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)