### PR TITLE
Fix ignored doctests (closes #22)

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -28,8 +28,8 @@
 //!   lib crate doesn't depend on [mod@tokio]. This is because [mod@tokio] is only used as a runtime for binray crate.
 //!
 //! ## Example
-//! ```ignore
-//! use rain_meta::{*, types::authoring::v1::AuthoringMeta};
+//! ```
+//! use rain_metadata::{*, types::authoring::v1::AuthoringMeta};
 //!
 //! let authoring_meta_content = r#"[
 //!   {

--- a/crates/cli/src/meta/mod.rs
+++ b/crates/cli/src/meta/mod.rs
@@ -507,15 +507,14 @@ impl NPE2Deployer {
 ///
 /// ## Examples
 ///
-/// ```ignore
-/// use rain_meta::Store;
+/// ```
+/// use rain_metadata::Store;
 /// use std::collections::HashMap;
 ///
-///
-/// // to instantiate with including default subgraphs
+/// // to instantiate without any default subgraphs
 /// let mut store = Store::new();
 ///
-/// // to instatiate with default rain subgraphs included
+/// // to instantiate with default rain subgraphs included
 /// let mut store = Store::default();
 ///
 /// // or to instantiate with initial values
@@ -524,44 +523,38 @@ impl NPE2Deployer {
 ///     &HashMap::new(),
 ///     &HashMap::new(),
 ///     &HashMap::new(),
-///     true
+///     true,
 /// );
 ///
 /// // add a new subgraph endpoint url to the subgraph list
 /// store.add_subgraphs(&vec!["sg-url-2".to_string()]);
 ///
-/// // update the store with another Store (merges the stores)
+/// // merge another Store into this one
 /// store.merge(&Store::default());
 ///
-/// // hash of a meta to search and store
-/// let hash = vec![0u8, 1u8, 2u8];
-///
-/// // updates the meta store with a new meta by searching through subgraphs
-/// store.update(&hash);
-///
 /// // updates the meta store with a new meta hash and bytes
+/// let hash = vec![0u8, 1u8, 2u8];
 /// store.update_with(&hash, &vec![0u8, 1u8]);
 ///
-/// // to get a record from store
-/// let meta = store.get_meta(&hash);
+/// // `Store::update(&hash)` is async; it searches each subgraph for `hash` and
+/// // populates the cache with the result. Call it from an async context with `.await`.
 ///
-/// // to get a deployer record from store
-/// let deployer_record = store.get_deployer(&hash);
+/// // to get a record from the store
+/// let _meta = store.get_meta(&hash);
 ///
-/// // path to a .rain file
+/// // to get a deployer record from the store
+/// let _deployer_record = store.get_deployer(&hash);
+///
+/// // Store is agnostic to dotrain contents — it just maps the hash of the content
+/// // to the given uri and puts it as a new meta into the meta cache.
 /// let dotrain_uri = "path/to/file.rain";
-///
-/// // reading the dotrain content as an example,
-/// // Store is agnostic to dotrain contents it just maps the hash of the content to the given
-/// // uri and puts it as a new meta into the meta cache, so obtaining and passing the correct
-/// // content is up to the implementer
-/// let dotrain_content = std::fs::read_to_string(&dotrain_uri).unwrap_or(String::new());
-///
-/// // updates the dotrain cache for a dotrain text and uri
-/// let (new_hash, old_hash) = store.set_dotrain(&dotrain_content, &dotrain_uri.to_string(), false).unwrap();
+/// let dotrain_content = "/* some dotrain source */";
+/// let (_new_hash, _old_hash) = store
+///     .set_dotrain(dotrain_content, dotrain_uri, false)
+///     .unwrap();
 ///
 /// // to get dotrain meta bytes given a uri
-/// let dotrain_meta_bytes = store.get_dotrain_meta(&dotrain_uri.to_string());
+/// let _dotrain_meta_bytes = store.get_dotrain_meta(dotrain_uri);
 /// ```
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Store {


### PR DESCRIPTION
## Summary
- Crate-level example used wrong crate name \`rain_meta\`; renamed to \`rain_metadata\`.
- Store doctest restructured to actually run (was \`ignore\`d): dropped the async \`Store::update\` call that the sync doctest couldn't await, replaced the placeholder file path with inline dotrain content.

Closes #22.

\`\`\`
running 2 tests
test crates/cli/src/meta/mod.rs - meta::Store (line 510) ... ok
test crates/cli/src/lib.rs - (line 31) ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
\`\`\`

## Test plan
- [ ] CI green (Rainix CI)
- [ ] \`cargo test --doc -p rain-metadata\` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation examples to reflect the current API design and proper usage patterns. Code samples have been refreshed to ensure they are accurate, executable, and aligned with the latest implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->