### PR TITLE
Add schema-check subcommand and pre-deploy guard (#58)

### DIFF
--- a/.github/workflows/manual-subgraph-deploy.yml
+++ b/.github/workflows/manual-subgraph-deploy.yml
@@ -1,17 +1,14 @@
 name: Subgraph manual deploy
 on: [workflow_dispatch]
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: recursive
-
       - uses: nixbuild/nix-quick-install-action@v30
         with:
           nix_conf: |
@@ -28,7 +25,8 @@ jobs:
           # before trying to save a new cache
           # 1G = 1073741824
           gc-max-store-size-linux: 1G
-
+      - name: Schema drift check (block deploy if consumer snapshot is stale)
+        run: nix develop --command cargo run -p rain-metadata --bin rain-metadata --quiet -- schema-check --source subgraph/schema.graphql --consumer crates/metaboard/src/schema/metaboard.graphql
       - run: nix develop --command subgraph-deploy
         env:
           GOLDSKY_TOKEN: ${{ secrets.CI_GOLDSKY_TOKEN }}

--- a/.github/workflows/manual-subgraph-deploy.yml
+++ b/.github/workflows/manual-subgraph-deploy.yml
@@ -3,6 +3,9 @@ on: [workflow_dispatch]
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      GOLDSKY_TOKEN: ${{ secrets.CI_GOLDSKY_TOKEN }}
+      GOLDSKY_SUBGRAPH_NAME: metaboard
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -17,17 +20,36 @@ jobs:
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:
-          # restore and save a cache using this key
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          # if there's no cache hit, restore a cache by this prefix
           restore-prefixes-first-match: nix-${{ runner.os }}-
-          # collect garbage until the Nix store size (in bytes) is at most this number
-          # before trying to save a new cache
-          # 1G = 1073741824
           gc-max-store-size-linux: 1G
-      - name: Schema drift check (block deploy if consumer snapshot is stale)
-        run: nix develop --command cargo run -p rain-metadata --bin rain-metadata --quiet -- schema-check --source subgraph/schema.graphql --consumer crates/metaboard/src/schema/metaboard.graphql
-      - run: nix develop --command subgraph-deploy
-        env:
-          GOLDSKY_TOKEN: ${{ secrets.CI_GOLDSKY_TOKEN }}
-          GOLDSKY_SUBGRAPH_NAME: metaboard
+      - name: Deploy and capture URLs
+        id: deploy
+        run: |
+          set -o pipefail
+          nix develop --command subgraph-deploy 2>&1 | tee deploy.log
+          echo
+          echo "::group::Deployed Goldsky URLs"
+          grep -oE 'https://api\.goldsky\.com/api/public/[^[:space:]]+/gn' deploy.log | sort -u | tee deployed_urls.txt
+          echo "::endgroup::"
+      - name: Schema check against live deployment
+        id: schema_check
+        run: |
+          URL=$(head -n 1 deployed_urls.txt)
+          if [ -z "$URL" ]; then
+            echo "::warning::no deployed URL captured; skipping live schema check"
+            exit 0
+          fi
+          echo "Introspecting: $URL"
+          nix develop --command cargo run -p rain-metadata --bin rain-metadata --quiet -- \
+            schema-check --live-url "$URL" --consumer crates/metaboard/src/schema/metaboard.graphql
+      - name: Rollback on schema failure
+        if: failure() && steps.schema_check.outcome == 'failure'
+        run: |
+          commit=$(git rev-parse --short HEAD)
+          for network in $(jq -r 'keys[]' subgraph/networks.json); do
+            address=$(jq -r --arg net "$network" '.[$net] | to_entries[0].value.address' subgraph/networks.json)
+            name_and_version="${GOLDSKY_SUBGRAPH_NAME}-${network}/${address}-${commit}"
+            echo "Rolling back ${name_and_version}..."
+            nix develop --command goldsky --token "${GOLDSKY_TOKEN}" subgraph delete "${name_and_version}" --force || echo "(delete failed for ${name_and_version}, may not exist)"
+          done

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -1,10 +1,8 @@
 name: Rainix CI
 on: [push]
-
 concurrency:
   group: ${{ github.ref }}-rainix
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
 jobs:
   standard-tests:
     strategy:
@@ -21,7 +19,6 @@ jobs:
           - os: ubuntu-latest
             task: rainix-rs-static
       fail-fast: false
-
     runs-on: ${{ matrix.os }}
     env:
       DEPLOYMENT_KEY: ${{ github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV }}
@@ -30,7 +27,6 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-
       - uses: nixbuild/nix-quick-install-action@v30
         with:
           nix_conf: |
@@ -44,7 +40,6 @@ jobs:
           # if there's no cache hit, restore a cache by this prefix
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 1G
-
       - run: nix develop -c rainix-sol-prelude
       - run: nix develop -c rainix-rs-prelude
       - name: Run ${{ matrix.task }}
@@ -58,6 +53,25 @@ jobs:
           CI_FORK_POLYGON_RPC_URL: ${{ secrets.CI_FORK_POLYGON_RPC_URL || vars.CI_FORK_POLYGON_RPC_URL || '' }}
           ETHERSCAN_API_KEY: ${{ secrets.EXPLORER_VERIFICATION_KEY }}
         run: nix develop -c ${{ matrix.task }}
-
       - name: Build for wasm target
         run: nix develop -c cargo build --target wasm32-unknown-unknown
+  schema-drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+      - name: Schema drift check
+        run: nix develop -c cargo run -p rain-metadata --bin rain-metadata --quiet -- schema-check --source subgraph/schema.graphql --consumer crates/metaboard/src/schema/metaboard.graphql

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -1,8 +1,10 @@
 name: Rainix CI
 on: [push]
+
 concurrency:
   group: ${{ github.ref }}-rainix
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   standard-tests:
     strategy:
@@ -19,6 +21,7 @@ jobs:
           - os: ubuntu-latest
             task: rainix-rs-static
       fail-fast: false
+
     runs-on: ${{ matrix.os }}
     env:
       DEPLOYMENT_KEY: ${{ github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV }}
@@ -27,6 +30,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+
       - uses: nixbuild/nix-quick-install-action@v30
         with:
           nix_conf: |
@@ -40,6 +44,7 @@ jobs:
           # if there's no cache hit, restore a cache by this prefix
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 1G
+
       - run: nix develop -c rainix-sol-prelude
       - run: nix develop -c rainix-rs-prelude
       - name: Run ${{ matrix.task }}
@@ -53,25 +58,6 @@ jobs:
           CI_FORK_POLYGON_RPC_URL: ${{ secrets.CI_FORK_POLYGON_RPC_URL || vars.CI_FORK_POLYGON_RPC_URL || '' }}
           ETHERSCAN_API_KEY: ${{ secrets.EXPLORER_VERIFICATION_KEY }}
         run: nix develop -c ${{ matrix.task }}
+
       - name: Build for wasm target
         run: nix develop -c cargo build --target wasm32-unknown-unknown
-  schema-drift-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          submodules: recursive
-      - uses: nixbuild/nix-quick-install-action@v30
-        with:
-          nix_conf: |
-            keep-env-derivations = true
-            keep-outputs = true
-      - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v7
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 1G
-      - name: Schema drift check
-        run: nix develop -c cargo run -p rain-metadata --bin rain-metadata --quiet -- schema-check --source subgraph/schema.graphql --consumer crates/metaboard/src/schema/metaboard.graphql

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3657,6 +3657,7 @@ dependencies = [
  "clap",
  "deflate",
  "futures",
+ "graphql-parser",
  "graphql_client",
  "httpmock",
  "inflate",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,7 +32,7 @@ deflate = "1.0.0"
 inflate = "0.4.5"
 serde_cbor = "0.11.2"
 validator = { version = "0.16", features = ["derive"] }
-reqwest = { version = "0.11.22", features = ["json"] }
+reqwest = { version = "0.11.22", features = ["json", "blocking"] }
 alloy = { version = "1.0.9", features = ["rand", "json", "json-abi"] }
 graphql_client = "0.13.0"
 graphql-parser = "0.4"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,6 +14,7 @@ cli = [
   "dep:tracing-subscriber",
   "dep:clap",
   "dep:tokio",
+  "dep:graphql-parser",
 ]
 json-schema = ["dep:schemars"]
 tokio-full = ["cli", "tokio/full"]
@@ -35,7 +36,7 @@ validator = { version = "0.16", features = ["derive"] }
 reqwest = { version = "0.11.22", features = ["json"] }
 alloy = { version = "1.0.9", features = ["rand", "json", "json-abi"] }
 graphql_client = "0.13.0"
-graphql-parser = "0.4"
+graphql-parser = { version = "0.4", optional = true }
 rain-metaboard-subgraph = { path = "../metaboard" }
 rain-metadata-bindings = { path = "../bindings" }
 thiserror = "1.0.56"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -8,7 +8,13 @@ repository = "https://github.com/rainlanguage/rain.metadata"
 
 [features]
 default = ["cli"]
-cli = ["json-schema", "dep:tracing", "dep:tracing-subscriber", "dep:clap", "dep:tokio"]
+cli = [
+  "json-schema",
+  "dep:tracing",
+  "dep:tracing-subscriber",
+  "dep:clap",
+  "dep:tokio",
+]
 json-schema = ["dep:schemars"]
 tokio-full = ["cli", "tokio/full"]
 
@@ -29,6 +35,7 @@ validator = { version = "0.16", features = ["derive"] }
 reqwest = { version = "0.11.22", features = ["json"] }
 alloy = { version = "1.0.9", features = ["rand", "json", "json-abi"] }
 graphql_client = "0.13.0"
+graphql-parser = "0.4"
 rain-metaboard-subgraph = { path = "../metaboard" }
 rain-metadata-bindings = { path = "../bindings" }
 thiserror = "1.0.56"
@@ -43,7 +50,13 @@ schemars = { version = "0.8.12", optional = true }
 tracing = { version = "0.1.37", optional = true }
 tracing-subscriber = { version = "0.3.17", optional = true }
 clap = { version = "4.4.8", features = ["cargo", "derive"], optional = true }
-tokio = { version = "1.34.0", features = ["sync", "macros", "io-util", "rt", "time"], optional = true }
+tokio = { version = "1.34.0", features = [
+  "sync",
+  "macros",
+  "io-util",
+  "rt",
+  "time",
+], optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 wasm-bindgen-utils = { git = "https://github.com/rainlanguage/rain.wasm", rev = "06990d85a0b7c55378a1c8cca4dd9e2bc34a596a" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,7 +32,7 @@ deflate = "1.0.0"
 inflate = "0.4.5"
 serde_cbor = "0.11.2"
 validator = { version = "0.16", features = ["derive"] }
-reqwest = { version = "0.11.22", features = ["json", "blocking"] }
+reqwest = { version = "0.11.22", features = ["json"] }
 alloy = { version = "1.0.9", features = ["rand", "json", "json-abi"] }
 graphql_client = "0.13.0"
 graphql-parser = "0.4"

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -8,6 +8,7 @@ pub mod solc;
 pub mod build;
 pub mod magic;
 pub mod schema;
+pub mod schema_check;
 pub mod output;
 pub mod subgraph;
 pub mod validate;
@@ -27,6 +28,7 @@ pub enum Meta {
     #[command(subcommand)]
     Schema(schema::Schema),
     Validate(validate::Validate),
+    SchemaCheck(schema_check::SchemaCheck),
     #[command(subcommand)]
     Magic(magic::Magic),
     Build(build::Build),
@@ -45,6 +47,7 @@ pub fn dispatch(meta: Meta) -> anyhow::Result<()> {
         Meta::Magic(magic) => magic::dispatch(magic),
         Meta::Schema(schema) => schema::dispatch(schema),
         Meta::Validate(validate) => validate::validate(validate),
+        Meta::SchemaCheck(c) => schema_check::schema_check(c),
         Meta::Generate(generate) => generate::generate(generate),
     }
 }

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -39,7 +39,7 @@ pub enum Meta {
     Generate(generate::Generate),
 }
 
-pub fn dispatch(meta: Meta) -> anyhow::Result<()> {
+pub async fn dispatch(meta: Meta) -> anyhow::Result<()> {
     match meta {
         Meta::Build(build) => build::build(build),
         Meta::Solc(solc) => solc::dispatch(solc),
@@ -47,13 +47,13 @@ pub fn dispatch(meta: Meta) -> anyhow::Result<()> {
         Meta::Magic(magic) => magic::dispatch(magic),
         Meta::Schema(schema) => schema::dispatch(schema),
         Meta::Validate(validate) => validate::validate(validate),
-        Meta::SchemaCheck(c) => schema_check::schema_check(c),
+        Meta::SchemaCheck(c) => schema_check::schema_check(c).await,
         Meta::Generate(generate) => generate::generate(generate),
     }
 }
 
-pub fn main() -> anyhow::Result<()> {
+pub async fn main() -> anyhow::Result<()> {
     tracing::subscriber::set_global_default(tracing_subscriber::fmt::Subscriber::new())?;
     let cli = Cli::parse();
-    dispatch(cli.meta)
+    dispatch(cli.meta).await
 }

--- a/crates/cli/src/cli/schema_check.rs
+++ b/crates/cli/src/cli/schema_check.rs
@@ -78,12 +78,18 @@ pub async fn schema_check(cmd: SchemaCheck) -> anyhow::Result<()> {
 /// fields. The synthetic SDL re-tags each type with `@entity` so the
 /// existing `entities` filter picks them up.
 async fn fetch_live_entities_as_sdl(url: &str) -> anyhow::Result<String> {
-    // Bound the request so a slow or hung Goldsky endpoint can't
-    // wedge the deploy job indefinitely.
+    // Bound the request so a slow or hung Goldsky endpoint can't wedge
+    // the deploy job indefinitely. reqwest's wasm impl uses the browser
+    // fetch API and doesn't expose ClientBuilder timing methods, so the
+    // bound is native-only. The CLI binary never runs under wasm.
+    #[cfg(not(target_family = "wasm"))]
     let client = reqwest::Client::builder()
         .connect_timeout(std::time::Duration::from_secs(10))
         .timeout(std::time::Duration::from_secs(30))
         .build()?;
+    #[cfg(target_family = "wasm")]
+    let client = reqwest::Client::new();
+
     let body = serde_json::json!({ "query": INTROSPECTION_QUERY });
     let resp: serde_json::Value = client
         .post(url)

--- a/crates/cli/src/cli/schema_check.rs
+++ b/crates/cli/src/cli/schema_check.rs
@@ -78,47 +78,40 @@ pub fn schema_check(cmd: SchemaCheck) -> anyhow::Result<()> {
 /// fields. The synthetic SDL re-tags each type with `@entity` so the
 /// existing `entities` filter picks them up.
 fn fetch_live_entities_as_sdl(url: &str) -> anyhow::Result<String> {
-    let runtime = tokio::runtime::Runtime::new()?;
-    runtime.block_on(async {
-        let client = reqwest::Client::new();
-        let body = serde_json::json!({ "query": INTROSPECTION_QUERY });
-        let resp: serde_json::Value = client
-            .post(url)
-            .json(&body)
-            .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await?;
-        if let Some(errors) = resp.get("errors") {
-            return Err(anyhow::anyhow!("introspection errors: {errors}"));
-        }
-        let types = resp
-            .pointer("/data/__schema/types")
-            .and_then(|t| t.as_array())
-            .ok_or_else(|| {
-                anyhow::anyhow!("introspection response missing /data/__schema/types")
-            })?;
+    let client = reqwest::blocking::Client::new();
+    let body = serde_json::json!({ "query": INTROSPECTION_QUERY });
+    let resp: serde_json::Value = client
+        .post(url)
+        .json(&body)
+        .send()?
+        .error_for_status()?
+        .json()?;
+    if let Some(errors) = resp.get("errors") {
+        return Err(anyhow::anyhow!("introspection errors: {errors}"));
+    }
+    let types = resp
+        .pointer("/data/__schema/types")
+        .and_then(|t| t.as_array())
+        .ok_or_else(|| anyhow::anyhow!("introspection response missing /data/__schema/types"))?;
 
-        let mut sdl = String::new();
-        for t in types {
-            let kind = t.get("kind").and_then(|v| v.as_str()).unwrap_or("");
-            let name = t.get("name").and_then(|v| v.as_str()).unwrap_or("");
-            if kind != "OBJECT" || !is_entity_object(name) {
-                continue;
-            }
-            sdl.push_str(&format!("type {name} @entity {{\n"));
-            if let Some(fields) = t.get("fields").and_then(|f| f.as_array()) {
-                for f in fields {
-                    let fname = f.get("name").and_then(|v| v.as_str()).unwrap_or("");
-                    let ftype = render_type(f.get("type").unwrap_or(&serde_json::Value::Null));
-                    sdl.push_str(&format!("  {fname}: {ftype}\n"));
-                }
-            }
-            sdl.push_str("}\n\n");
+    let mut sdl = String::new();
+    for t in types {
+        let kind = t.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+        let name = t.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        if kind != "OBJECT" || !is_entity_object(name) {
+            continue;
         }
-        Ok(sdl)
-    })
+        sdl.push_str(&format!("type {name} @entity {{\n"));
+        if let Some(fields) = t.get("fields").and_then(|f| f.as_array()) {
+            for f in fields {
+                let fname = f.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                let ftype = render_type(f.get("type").unwrap_or(&serde_json::Value::Null));
+                sdl.push_str(&format!("  {fname}: {ftype}\n"));
+            }
+        }
+        sdl.push_str("}\n\n");
+    }
+    Ok(sdl)
 }
 
 /// Filter for "entity-shaped" Object types in a Graph Protocol introspection

--- a/crates/cli/src/cli/schema_check.rs
+++ b/crates/cli/src/cli/schema_check.rs
@@ -5,6 +5,15 @@ use graphql_parser::schema::{
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+const INTROSPECTION_QUERY: &str = r#"
+{ __schema { types {
+  kind name
+  fields(includeDeprecated: true) {
+    name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } }
+  }
+} } }
+"#;
+
 /// Compare entity types in a subgraph schema against a consumer's snapshot
 /// of the deployed introspection schema. Used in deploy CI to fail early
 /// when the consumer's snapshot has drifted from what is about to be
@@ -12,20 +21,39 @@ use std::path::PathBuf;
 #[derive(Parser)]
 pub struct SchemaCheck {
     /// Path to the source subgraph schema (with `@entity` directives).
-    #[arg(short, long)]
-    pub source: PathBuf,
+    /// Mutually exclusive with --live-url.
+    #[arg(short, long, conflicts_with = "live_url")]
+    pub source: Option<PathBuf>,
+    /// URL of a live deployed subgraph endpoint. Introspection is fetched
+    /// and used as the source of truth in place of --source. The full
+    /// introspection-derived SDL of the entity types is printed on
+    /// failure so the consumer snapshot can be regenerated.
+    #[arg(short, long, conflicts_with = "source")]
+    pub live_url: Option<String>,
     /// Path to the consumer's snapshot of the deployed introspection schema.
     #[arg(short, long)]
     pub consumer: PathBuf,
 }
 
 pub fn schema_check(cmd: SchemaCheck) -> anyhow::Result<()> {
-    let source_sdl = std::fs::read_to_string(&cmd.source)?;
     let consumer_sdl = std::fs::read_to_string(&cmd.consumer)?;
+
+    let (source_sdl, source_label) = match (&cmd.source, &cmd.live_url) {
+        (Some(path), None) => (std::fs::read_to_string(path)?, "source".to_string()),
+        (None, Some(url)) => {
+            let sdl = fetch_live_entities_as_sdl(url)?;
+            (sdl, format!("live ({url})"))
+        }
+        _ => {
+            return Err(anyhow::anyhow!(
+                "exactly one of --source or --live-url must be provided"
+            ));
+        }
+    };
 
     match check(&source_sdl, &consumer_sdl) {
         Ok(count) => {
-            println!("schema check ok: {count} entities verified");
+            println!("schema check ok: {count} entities verified against {source_label}");
             Ok(())
         }
         Err(errors) => {
@@ -34,8 +62,92 @@ pub fn schema_check(cmd: SchemaCheck) -> anyhow::Result<()> {
                 msg.push_str("\n  - ");
                 msg.push_str(e);
             }
+            if cmd.live_url.is_some() {
+                msg.push_str(
+                    "\n\nLive introspection-derived entity SDL (copy into consumer file):\n",
+                );
+                msg.push_str(&source_sdl);
+            }
             Err(anyhow::anyhow!(msg))
         }
+    }
+}
+
+/// POST a GraphQL introspection query to `url` and reduce the response to
+/// a synthetic SDL document containing only entity Object types and their
+/// fields. The synthetic SDL re-tags each type with `@entity` so the
+/// existing `entities` filter picks them up.
+fn fetch_live_entities_as_sdl(url: &str) -> anyhow::Result<String> {
+    let runtime = tokio::runtime::Runtime::new()?;
+    runtime.block_on(async {
+        let client = reqwest::Client::new();
+        let body = serde_json::json!({ "query": INTROSPECTION_QUERY });
+        let resp: serde_json::Value = client
+            .post(url)
+            .json(&body)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        if let Some(errors) = resp.get("errors") {
+            return Err(anyhow::anyhow!("introspection errors: {errors}"));
+        }
+        let types = resp
+            .pointer("/data/__schema/types")
+            .and_then(|t| t.as_array())
+            .ok_or_else(|| {
+                anyhow::anyhow!("introspection response missing /data/__schema/types")
+            })?;
+
+        let mut sdl = String::new();
+        for t in types {
+            let kind = t.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+            let name = t.get("name").and_then(|v| v.as_str()).unwrap_or("");
+            if kind != "OBJECT" || !is_entity_object(name) {
+                continue;
+            }
+            sdl.push_str(&format!("type {name} @entity {{\n"));
+            if let Some(fields) = t.get("fields").and_then(|f| f.as_array()) {
+                for f in fields {
+                    let fname = f.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                    let ftype = render_type(f.get("type").unwrap_or(&serde_json::Value::Null));
+                    sdl.push_str(&format!("  {fname}: {ftype}\n"));
+                }
+            }
+            sdl.push_str("}\n\n");
+        }
+        Ok(sdl)
+    })
+}
+
+/// Filter for "entity-shaped" Object types in a Graph Protocol introspection
+/// response: skip auto-generated derivative types (filter, orderBy, Query,
+/// Subscription, _Meta_, _Block_, etc.) and any name with a leading underscore.
+fn is_entity_object(name: &str) -> bool {
+    !name.is_empty()
+        && !name.starts_with('_')
+        && name != "Query"
+        && name != "Subscription"
+        && !name.ends_with("_filter")
+        && !name.ends_with("_orderBy")
+}
+
+/// Render an introspection type-ref into SDL syntax (`Bytes!`, `[Foo!]!`).
+fn render_type(t: &serde_json::Value) -> String {
+    let kind = t.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+    let name = t.get("name").and_then(|v| v.as_str());
+    let of_type = t.get("ofType");
+    match kind {
+        "NON_NULL" => format!(
+            "{}!",
+            render_type(of_type.unwrap_or(&serde_json::Value::Null))
+        ),
+        "LIST" => format!(
+            "[{}]",
+            render_type(of_type.unwrap_or(&serde_json::Value::Null))
+        ),
+        _ => name.unwrap_or("Unknown").to_string(),
     }
 }
 

--- a/crates/cli/src/cli/schema_check.rs
+++ b/crates/cli/src/cli/schema_check.rs
@@ -78,7 +78,12 @@ pub async fn schema_check(cmd: SchemaCheck) -> anyhow::Result<()> {
 /// fields. The synthetic SDL re-tags each type with `@entity` so the
 /// existing `entities` filter picks them up.
 async fn fetch_live_entities_as_sdl(url: &str) -> anyhow::Result<String> {
-    let client = reqwest::Client::new();
+    // Bound the request so a slow or hung Goldsky endpoint can't
+    // wedge the deploy job indefinitely.
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(30))
+        .build()?;
     let body = serde_json::json!({ "query": INTROSPECTION_QUERY });
     let resp: serde_json::Value = client
         .post(url)
@@ -154,6 +159,14 @@ fn check(source_sdl: &str, consumer_sdl: &str) -> Result<usize, Vec<String>> {
 
     let source_entities = entities(&source_doc);
     let consumer_objects = all_objects(&consumer_doc);
+
+    if source_entities.is_empty() {
+        return Err(vec![
+            "source schema has no `@entity` types; check that --source/--live-url \
+             points at a subgraph SDL or live introspection endpoint"
+                .to_string(),
+        ]);
+    }
 
     let mut errors = Vec::new();
 
@@ -389,13 +402,14 @@ mod tests {
     }
 
     #[test]
-    fn empty_source_passes_with_zero_entities() {
-        // No `@entity` types in source means nothing to verify; consumer
-        // can have anything.
+    fn source_with_no_entities_is_an_error() {
+        // Silently passing with 0 entities verified would mask a
+        // misconfigured --source path or a non-subgraph SDL in CI.
         let source = "scalar Bytes";
         let consumer = "type Whatever { x: Int }";
-        let n = check(source, consumer).unwrap();
-        assert_eq!(n, 0);
+        let errs = check(source, consumer).unwrap_err();
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("no `@entity` types"));
     }
 
     #[test]

--- a/crates/cli/src/cli/schema_check.rs
+++ b/crates/cli/src/cli/schema_check.rs
@@ -164,7 +164,7 @@ fn check(source_sdl: &str, consumer_sdl: &str) -> Result<usize, Vec<String>> {
         parse_schema(consumer_sdl).map_err(|e| vec![format!("parse consumer: {e}")])?;
 
     let source_entities = entities(&source_doc);
-    let consumer_objects = all_objects(&consumer_doc);
+    let consumer_field_index = build_field_index(&consumer_doc);
 
     if source_entities.is_empty() {
         return Err(vec![
@@ -177,17 +177,12 @@ fn check(source_sdl: &str, consumer_sdl: &str) -> Result<usize, Vec<String>> {
     let mut errors = Vec::new();
 
     for entity in &source_entities {
-        match consumer_objects.get(entity.name.as_str()) {
+        match consumer_field_index.get(entity.name.as_str()) {
             None => errors.push(format!(
                 "entity `{}` is missing from consumer schema",
                 entity.name
             )),
-            Some(consumer_entity) => {
-                let consumer_fields: BTreeMap<&str, &Field<'_, String>> = consumer_entity
-                    .fields
-                    .iter()
-                    .map(|f| (f.name.as_str(), f))
-                    .collect();
+            Some(consumer_fields) => {
                 for field in &entity.fields {
                     match consumer_fields.get(field.name.as_str()) {
                         None => errors.push(format!(
@@ -232,12 +227,19 @@ fn entities<'a>(doc: &'a Document<'a, String>) -> Vec<&'a ObjectType<'a, String>
         .collect()
 }
 
-fn all_objects<'a>(doc: &'a Document<'a, String>) -> BTreeMap<&'a str, &'a ObjectType<'a, String>> {
+/// Build a name → (field-name → field) lookup over every Object type in
+/// the document, so the per-entity field map isn't reconstructed inside
+/// the comparison loop.
+fn build_field_index<'a>(
+    doc: &'a Document<'a, String>,
+) -> BTreeMap<&'a str, BTreeMap<&'a str, &'a Field<'a, String>>> {
     doc.definitions
         .iter()
         .filter_map(|def| {
             if let Definition::TypeDefinition(TypeDefinition::Object(obj)) = def {
-                Some((obj.name.as_str(), obj))
+                let fields: BTreeMap<&str, &Field<'_, String>> =
+                    obj.fields.iter().map(|f| (f.name.as_str(), f)).collect();
+                Some((obj.name.as_str(), fields))
             } else {
                 None
             }
@@ -668,20 +670,24 @@ mod tests {
     }
 
     #[test]
-    fn all_objects_returns_every_object_type_keyed_by_name() {
+    fn build_field_index_returns_field_maps_keyed_by_object_name() {
         let doc = parse(
             r#"
-            type A { x: Int }
+            type A { x: Int y: String }
             type B @entity { y: Int }
             scalar S
             enum E { X }
             input I { z: Int }
             "#,
         );
-        let m = all_objects(&doc);
+        let m = build_field_index(&doc);
         let mut names: Vec<&str> = m.keys().copied().collect();
         names.sort();
         assert_eq!(names, vec!["A", "B"]);
+        let mut a_fields: Vec<&str> = m["A"].keys().copied().collect();
+        a_fields.sort();
+        assert_eq!(a_fields, vec!["x", "y"]);
+        assert_eq!(m["B"].keys().copied().collect::<Vec<_>>(), vec!["y"]);
     }
 
     fn named(s: &str) -> Type<'static, String> {

--- a/crates/cli/src/cli/schema_check.rs
+++ b/crates/cli/src/cli/schema_check.rs
@@ -1,0 +1,283 @@
+use clap::Parser;
+use graphql_parser::schema::{
+    parse_schema, Definition, Document, Field, ObjectType, Type, TypeDefinition,
+};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+/// Compare entity types in a subgraph schema against a consumer's snapshot
+/// of the deployed introspection schema. Used in deploy CI to fail early
+/// when the consumer's snapshot has drifted from what is about to be
+/// deployed.
+#[derive(Parser)]
+pub struct SchemaCheck {
+    /// Path to the source subgraph schema (with `@entity` directives).
+    #[arg(short, long)]
+    pub source: PathBuf,
+    /// Path to the consumer's snapshot of the deployed introspection schema.
+    #[arg(short, long)]
+    pub consumer: PathBuf,
+}
+
+pub fn schema_check(cmd: SchemaCheck) -> anyhow::Result<()> {
+    let source_sdl = std::fs::read_to_string(&cmd.source)?;
+    let consumer_sdl = std::fs::read_to_string(&cmd.consumer)?;
+
+    match check(&source_sdl, &consumer_sdl) {
+        Ok(count) => {
+            println!("schema check ok: {count} entities verified");
+            Ok(())
+        }
+        Err(errors) => {
+            let mut msg = format!("schema check failed with {} mismatches:", errors.len());
+            for e in &errors {
+                msg.push_str("\n  - ");
+                msg.push_str(e);
+            }
+            Err(anyhow::anyhow!(msg))
+        }
+    }
+}
+
+fn check(source_sdl: &str, consumer_sdl: &str) -> Result<usize, Vec<String>> {
+    let source_doc: Document<String> =
+        parse_schema(source_sdl).map_err(|e| vec![format!("parse source: {e}")])?;
+    let consumer_doc: Document<String> =
+        parse_schema(consumer_sdl).map_err(|e| vec![format!("parse consumer: {e}")])?;
+
+    let source_entities = entities(&source_doc);
+    let consumer_objects = all_objects(&consumer_doc);
+
+    let mut errors = Vec::new();
+
+    for entity in &source_entities {
+        match consumer_objects.get(entity.name.as_str()) {
+            None => errors.push(format!(
+                "entity `{}` is missing from consumer schema",
+                entity.name
+            )),
+            Some(consumer_entity) => {
+                let consumer_fields: BTreeMap<&str, &Field<'_, String>> = consumer_entity
+                    .fields
+                    .iter()
+                    .map(|f| (f.name.as_str(), f))
+                    .collect();
+                for field in &entity.fields {
+                    match consumer_fields.get(field.name.as_str()) {
+                        None => errors.push(format!(
+                            "field `{}.{}` is missing from consumer schema",
+                            entity.name, field.name
+                        )),
+                        Some(consumer_field) => {
+                            if !type_equal(&field.field_type, &consumer_field.field_type) {
+                                errors.push(format!(
+                                    "field `{}.{}` type mismatch: source `{}` vs consumer `{}`",
+                                    entity.name,
+                                    field.name,
+                                    type_to_string(&field.field_type),
+                                    type_to_string(&consumer_field.field_type),
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(source_entities.len())
+    } else {
+        Err(errors)
+    }
+}
+
+fn entities<'a>(doc: &'a Document<'a, String>) -> Vec<&'a ObjectType<'a, String>> {
+    doc.definitions
+        .iter()
+        .filter_map(|def| {
+            if let Definition::TypeDefinition(TypeDefinition::Object(obj)) = def {
+                if obj.directives.iter().any(|d| d.name == "entity") {
+                    return Some(obj);
+                }
+            }
+            None
+        })
+        .collect()
+}
+
+fn all_objects<'a>(doc: &'a Document<'a, String>) -> BTreeMap<&'a str, &'a ObjectType<'a, String>> {
+    doc.definitions
+        .iter()
+        .filter_map(|def| {
+            if let Definition::TypeDefinition(TypeDefinition::Object(obj)) = def {
+                Some((obj.name.as_str(), obj))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn type_equal(a: &Type<'_, String>, b: &Type<'_, String>) -> bool {
+    match (a, b) {
+        (Type::NamedType(an), Type::NamedType(bn)) => an == bn,
+        (Type::ListType(ai), Type::ListType(bi)) => type_equal(ai, bi),
+        (Type::NonNullType(ai), Type::NonNullType(bi)) => type_equal(ai, bi),
+        _ => false,
+    }
+}
+
+fn type_to_string(t: &Type<'_, String>) -> String {
+    match t {
+        Type::NamedType(n) => n.clone(),
+        Type::ListType(inner) => format!("[{}]", type_to_string(inner)),
+        Type::NonNullType(inner) => format!("{}!", type_to_string(inner)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SOURCE_OK: &str = r#"
+        type MetaBoard @entity {
+            id: Bytes!
+            address: Bytes!
+            nextMetaId: BigInt!
+        }
+        type MetaV1 @entity {
+            id: ID!
+            sender: Bytes!
+            subject: Bytes!
+        }
+    "#;
+
+    const CONSUMER_OK: &str = r#"
+        type MetaBoard {
+          id: Bytes!
+          address: Bytes!
+          nextMetaId: BigInt!
+        }
+        type MetaV1 {
+          id: ID!
+          sender: Bytes!
+          subject: Bytes!
+        }
+    "#;
+
+    #[test]
+    fn matching_schemas_pass() {
+        let n = check(SOURCE_OK, CONSUMER_OK).unwrap();
+        assert_eq!(n, 2);
+    }
+
+    #[test]
+    fn missing_entity_is_reported() {
+        let consumer = r#"
+            type MetaBoard {
+              id: Bytes!
+              address: Bytes!
+              nextMetaId: BigInt!
+            }
+        "#;
+        let errs = check(SOURCE_OK, consumer).unwrap_err();
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("entity `MetaV1` is missing"));
+    }
+
+    #[test]
+    fn missing_field_is_reported() {
+        let consumer = r#"
+            type MetaBoard {
+              id: Bytes!
+              address: Bytes!
+              nextMetaId: BigInt!
+            }
+            type MetaV1 {
+              id: ID!
+              sender: Bytes!
+            }
+        "#;
+        let errs = check(SOURCE_OK, consumer).unwrap_err();
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("field `MetaV1.subject` is missing"));
+    }
+
+    #[test]
+    fn type_mismatch_is_reported() {
+        let consumer = r#"
+            type MetaBoard {
+              id: Bytes!
+              address: Bytes!
+              nextMetaId: BigInt!
+            }
+            type MetaV1 {
+              id: ID!
+              sender: Bytes!
+              subject: BigInt!
+            }
+        "#;
+        let errs = check(SOURCE_OK, consumer).unwrap_err();
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("`MetaV1.subject` type mismatch"));
+        assert!(errs[0].contains("source `Bytes!`"));
+        assert!(errs[0].contains("consumer `BigInt!`"));
+    }
+
+    #[test]
+    fn deployed_subgraph_drift_is_caught() {
+        // Mirrors the actual divergence between subgraph/schema.graphql
+        // (source) and crates/metaboard/src/schema/metaboard.graphql
+        // (consumer) at the time this subcommand was added: missing
+        // `Transaction` entity and `MetaV1.transaction`, plus `subject`
+        // type mismatch (Bytes! vs BigInt!).
+        let source = r#"
+            type MetaBoard @entity {
+                id: Bytes!
+                address: Bytes!
+                nextMetaId: BigInt!
+            }
+            type MetaV1 @entity {
+                id: ID!
+                transaction: Transaction!
+                metaBoard: MetaBoard!
+                sender: Bytes!
+                subject: Bytes!
+                metaHash: Bytes!
+                meta: Bytes!
+            }
+            type Transaction @entity(immutable: true) {
+                id: Bytes!
+                timestamp: BigInt!
+                blockNumber: BigInt!
+                from: Bytes!
+            }
+        "#;
+        let consumer = r#"
+            type MetaBoard {
+              id: Bytes!
+              address: Bytes!
+              nextMetaId: BigInt!
+            }
+            type MetaV1 {
+              id: ID!
+              metaBoard: MetaBoard!
+              sender: Bytes!
+              subject: BigInt!
+              metaHash: Bytes!
+              meta: Bytes!
+            }
+        "#;
+        let errs = check(source, consumer).unwrap_err();
+        assert!(errs
+            .iter()
+            .any(|e| e.contains("entity `Transaction` is missing")));
+        assert!(errs
+            .iter()
+            .any(|e| e.contains("field `MetaV1.transaction` is missing")));
+        assert!(errs
+            .iter()
+            .any(|e| e.contains("`MetaV1.subject` type mismatch")));
+    }
+}

--- a/crates/cli/src/cli/schema_check.rs
+++ b/crates/cli/src/cli/schema_check.rs
@@ -280,4 +280,241 @@ mod tests {
             .iter()
             .any(|e| e.contains("`MetaV1.subject` type mismatch")));
     }
+
+    #[test]
+    fn empty_source_passes_with_zero_entities() {
+        // No `@entity` types in source means nothing to verify; consumer
+        // can have anything.
+        let source = "scalar Bytes";
+        let consumer = "type Whatever { x: Int }";
+        let n = check(source, consumer).unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn non_object_definitions_in_source_are_ignored() {
+        // Enums, scalars, and Object types without `@entity` must not be
+        // treated as entities to check.
+        let source = r#"
+            scalar Bytes
+            enum Direction { ASC DESC }
+            type NotAnEntity {
+                noisefield: Int
+            }
+            type MetaBoard @entity {
+                id: Bytes!
+            }
+        "#;
+        let consumer = r#"
+            type MetaBoard {
+              id: Bytes!
+            }
+        "#;
+        let n = check(source, consumer).unwrap();
+        assert_eq!(n, 1, "only the @entity-tagged type should be verified");
+    }
+
+    #[test]
+    fn entity_directive_with_arguments_is_detected() {
+        // `@entity(immutable: true)` must still be picked up.
+        let source = r#"
+            type Transaction @entity(immutable: true) {
+                id: Bytes!
+            }
+        "#;
+        let consumer = r#"
+            type Transaction {
+              id: Bytes!
+            }
+        "#;
+        let n = check(source, consumer).unwrap();
+        assert_eq!(n, 1);
+    }
+
+    #[test]
+    fn consumer_extras_are_ignored() {
+        // The consumer schema is the introspected GraphQL service surface
+        // and contains derivative types (filters, orderBy) plus extra
+        // fields with arguments. Those must not cause errors.
+        let consumer = r#"
+            type MetaBoard {
+              id: Bytes!
+              address: Bytes!
+              nextMetaId: BigInt!
+              extraField: String
+            }
+            type MetaV1 {
+              id: ID!
+              sender: Bytes!
+              subject: Bytes!
+            }
+            input MetaBoard_filter {
+              id: Bytes
+            }
+            enum MetaBoard_orderBy { id address }
+        "#;
+        let n = check(SOURCE_OK, consumer).unwrap();
+        assert_eq!(n, 2);
+    }
+
+    #[test]
+    fn consumer_field_with_arguments_matches_when_return_type_matches() {
+        // Introspected derived fields look like `metas(skip: Int = 0, ...): [MetaV1!]`.
+        // We compare only the return type, not the args, so this must pass.
+        let source = r#"
+            type MetaBoard @entity {
+                id: Bytes!
+                metas: [MetaV1!]
+            }
+            type MetaV1 @entity {
+                id: ID!
+            }
+        "#;
+        let consumer = r#"
+            type MetaBoard {
+              id: Bytes!
+              metas(skip: Int = 0, first: Int = 100): [MetaV1!]
+            }
+            type MetaV1 {
+              id: ID!
+            }
+        "#;
+        let n = check(source, consumer).unwrap();
+        assert_eq!(n, 2);
+    }
+
+    #[test]
+    fn nullability_mismatch_is_reported() {
+        // `Bytes` (nullable) vs `Bytes!` (non-null) are distinct types
+        // and must be flagged.
+        let source = r#"
+            type MetaBoard @entity {
+                id: Bytes!
+            }
+        "#;
+        let consumer = r#"
+            type MetaBoard {
+              id: Bytes
+            }
+        "#;
+        let errs = check(source, consumer).unwrap_err();
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("source `Bytes!`"));
+        assert!(errs[0].contains("consumer `Bytes`"));
+    }
+
+    #[test]
+    fn list_vs_scalar_mismatch_is_reported() {
+        let source = r#"
+            type MetaBoard @entity {
+                metas: [MetaV1!]
+            }
+            type MetaV1 @entity {
+                id: ID!
+            }
+        "#;
+        let consumer = r#"
+            type MetaBoard {
+              metas: MetaV1
+            }
+            type MetaV1 {
+              id: ID!
+            }
+        "#;
+        let errs = check(source, consumer).unwrap_err();
+        assert!(errs
+            .iter()
+            .any(|e| e.contains("`MetaBoard.metas` type mismatch")));
+        assert!(errs.iter().any(|e| e.contains("source `[MetaV1!]`")));
+    }
+
+    #[test]
+    fn nested_wrapper_types_compare_recursively() {
+        // `[Bytes!]!` must match `[Bytes!]!` exactly and differ from `[Bytes!]`.
+        let source = r#"
+            type MetaBoard @entity {
+                tags: [Bytes!]!
+            }
+        "#;
+        let ok_consumer = r#"
+            type MetaBoard {
+              tags: [Bytes!]!
+            }
+        "#;
+        let n = check(source, ok_consumer).unwrap();
+        assert_eq!(n, 1);
+
+        let bad_consumer = r#"
+            type MetaBoard {
+              tags: [Bytes!]
+            }
+        "#;
+        let errs = check(source, bad_consumer).unwrap_err();
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("source `[Bytes!]!`"));
+        assert!(errs[0].contains("consumer `[Bytes!]`"));
+    }
+
+    #[test]
+    fn multiple_errors_are_all_reported() {
+        // One run should surface every problem, not stop at the first.
+        let source = r#"
+            type MetaBoard @entity {
+                id: Bytes!
+                address: Bytes!
+                nextMetaId: BigInt!
+            }
+            type MetaV1 @entity {
+                id: ID!
+                sender: Bytes!
+                subject: Bytes!
+            }
+            type Transaction @entity {
+                id: Bytes!
+            }
+        "#;
+        let consumer = r#"
+            type MetaBoard {
+              id: Bytes!
+              address: BigInt!
+            }
+            type MetaV1 {
+              id: ID!
+              sender: Bytes!
+            }
+        "#;
+        let errs = check(source, consumer).unwrap_err();
+        // MetaBoard.address mismatch + MetaBoard.nextMetaId missing
+        // + MetaV1.subject missing + Transaction entity missing = 4
+        assert_eq!(errs.len(), 4, "errors were: {:?}", errs);
+    }
+
+    #[test]
+    fn unparseable_source_is_reported() {
+        let errs = check("type Broken @entity {", CONSUMER_OK).unwrap_err();
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].starts_with("parse source:"));
+    }
+
+    #[test]
+    fn unparseable_consumer_is_reported() {
+        let errs = check(SOURCE_OK, "type Broken {").unwrap_err();
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].starts_with("parse consumer:"));
+    }
+
+    #[test]
+    fn consumer_with_no_objects_reports_every_source_entity_missing() {
+        // Use a valid-but-Object-free schema (graphql-parser rejects fully
+        // empty input as a parse error, which is its own test case).
+        let errs = check(SOURCE_OK, "scalar Whatever").unwrap_err();
+        // SOURCE_OK has 2 entities (MetaBoard, MetaV1).
+        assert_eq!(errs.len(), 2);
+        assert!(errs
+            .iter()
+            .any(|e| e.contains("entity `MetaBoard` is missing")));
+        assert!(errs
+            .iter()
+            .any(|e| e.contains("entity `MetaV1` is missing")));
+    }
 }

--- a/crates/cli/src/cli/schema_check.rs
+++ b/crates/cli/src/cli/schema_check.rs
@@ -35,13 +35,13 @@ pub struct SchemaCheck {
     pub consumer: PathBuf,
 }
 
-pub fn schema_check(cmd: SchemaCheck) -> anyhow::Result<()> {
+pub async fn schema_check(cmd: SchemaCheck) -> anyhow::Result<()> {
     let consumer_sdl = std::fs::read_to_string(&cmd.consumer)?;
 
     let (source_sdl, source_label) = match (&cmd.source, &cmd.live_url) {
         (Some(path), None) => (std::fs::read_to_string(path)?, "source".to_string()),
         (None, Some(url)) => {
-            let sdl = fetch_live_entities_as_sdl(url)?;
+            let sdl = fetch_live_entities_as_sdl(url).await?;
             (sdl, format!("live ({url})"))
         }
         _ => {
@@ -77,15 +77,17 @@ pub fn schema_check(cmd: SchemaCheck) -> anyhow::Result<()> {
 /// a synthetic SDL document containing only entity Object types and their
 /// fields. The synthetic SDL re-tags each type with `@entity` so the
 /// existing `entities` filter picks them up.
-fn fetch_live_entities_as_sdl(url: &str) -> anyhow::Result<String> {
-    let client = reqwest::blocking::Client::new();
+async fn fetch_live_entities_as_sdl(url: &str) -> anyhow::Result<String> {
+    let client = reqwest::Client::new();
     let body = serde_json::json!({ "query": INTROSPECTION_QUERY });
     let resp: serde_json::Value = client
         .post(url)
         .json(&body)
-        .send()?
+        .send()
+        .await?
         .error_for_status()?
-        .json()?;
+        .json()
+        .await?;
     if let Some(errors) = resp.get("errors") {
         return Err(anyhow::anyhow!("introspection errors: {errors}"));
     }

--- a/crates/cli/src/cli/schema_check.rs
+++ b/crates/cli/src/cli/schema_check.rs
@@ -638,4 +638,299 @@ mod tests {
             .iter()
             .any(|e| e.contains("entity `MetaV1` is missing")));
     }
+
+    // ---------- helper-function unit tests ----------
+
+    fn parse(sdl: &str) -> Document<'_, String> {
+        parse_schema(sdl).unwrap()
+    }
+
+    #[test]
+    fn entities_returns_only_entity_directive_objects() {
+        let doc = parse(
+            r#"
+            type WithEntity @entity { id: ID! }
+            type WithEntityArgs @entity(immutable: true) { id: ID! }
+            type Plain { id: ID! }
+            type WithOtherDirective @other { id: ID! }
+            scalar S
+            enum E { A B }
+            "#,
+        );
+        let names: Vec<&str> = entities(&doc).iter().map(|o| o.name.as_str()).collect();
+        assert_eq!(names, vec!["WithEntity", "WithEntityArgs"]);
+    }
+
+    #[test]
+    fn all_objects_returns_every_object_type_keyed_by_name() {
+        let doc = parse(
+            r#"
+            type A { x: Int }
+            type B @entity { y: Int }
+            scalar S
+            enum E { X }
+            input I { z: Int }
+            "#,
+        );
+        let m = all_objects(&doc);
+        let mut names: Vec<&str> = m.keys().copied().collect();
+        names.sort();
+        assert_eq!(names, vec!["A", "B"]);
+    }
+
+    fn named(s: &str) -> Type<'static, String> {
+        Type::NamedType(s.to_string())
+    }
+    fn nn(t: Type<'static, String>) -> Type<'static, String> {
+        Type::NonNullType(Box::new(t))
+    }
+    fn list(t: Type<'static, String>) -> Type<'static, String> {
+        Type::ListType(Box::new(t))
+    }
+
+    #[test]
+    fn type_equal_named_named() {
+        assert!(type_equal(&named("Bytes"), &named("Bytes")));
+        assert!(!type_equal(&named("Bytes"), &named("BigInt")));
+    }
+
+    #[test]
+    fn type_equal_distinguishes_wrappers() {
+        assert!(!type_equal(&named("Bytes"), &nn(named("Bytes"))));
+        assert!(!type_equal(&named("Bytes"), &list(named("Bytes"))));
+        assert!(!type_equal(&nn(named("Bytes")), &list(named("Bytes"))));
+    }
+
+    #[test]
+    fn type_equal_recurses_through_nested_wrappers() {
+        let a = nn(list(nn(named("Bytes"))));
+        let b = nn(list(nn(named("Bytes"))));
+        assert!(type_equal(&a, &b));
+        let c = nn(list(named("Bytes")));
+        assert!(!type_equal(&a, &c));
+    }
+
+    #[test]
+    fn type_to_string_renders_sdl_syntax() {
+        assert_eq!(type_to_string(&named("Bytes")), "Bytes");
+        assert_eq!(type_to_string(&nn(named("Bytes"))), "Bytes!");
+        assert_eq!(type_to_string(&list(named("X"))), "[X]");
+        assert_eq!(type_to_string(&nn(list(nn(named("X"))))), "[X!]!");
+    }
+
+    #[test]
+    fn is_entity_object_skips_derivative_and_internal_types() {
+        assert!(is_entity_object("MetaBoard"));
+        assert!(is_entity_object("Transaction"));
+        assert!(!is_entity_object(""));
+        assert!(!is_entity_object("_Meta_"));
+        assert!(!is_entity_object("Query"));
+        assert!(!is_entity_object("Subscription"));
+        assert!(!is_entity_object("MetaV1_filter"));
+        assert!(!is_entity_object("MetaV1_orderBy"));
+    }
+
+    #[test]
+    fn render_type_unwraps_introspection_typeref_recursively() {
+        // NON_NULL[LIST[NON_NULL[Bytes]]] → "[Bytes!]!"
+        let nested = serde_json::json!({
+            "kind": "NON_NULL",
+            "name": null,
+            "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": { "kind": "SCALAR", "name": "Bytes", "ofType": null }
+                }
+            }
+        });
+        assert_eq!(render_type(&nested), "[Bytes!]!");
+    }
+
+    #[test]
+    fn render_type_handles_plain_named_type() {
+        let scalar = serde_json::json!({ "kind": "SCALAR", "name": "BigInt", "ofType": null });
+        assert_eq!(render_type(&scalar), "BigInt");
+    }
+
+    #[test]
+    fn render_type_falls_back_to_unknown_for_missing_name() {
+        let bad = serde_json::json!({ "kind": "SCALAR", "name": null, "ofType": null });
+        assert_eq!(render_type(&bad), "Unknown");
+    }
+
+    // ---------- live-URL HTTP path ----------
+
+    #[tokio::test]
+    async fn fetch_live_entities_filters_to_entity_object_types() {
+        use httpmock::Method::POST;
+        use httpmock::MockServer;
+
+        let server = MockServer::start_async().await;
+        let _mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path("/");
+                then.status(200).json_body(serde_json::json!({
+                "data": { "__schema": { "types": [
+                    { "kind": "OBJECT", "name": "MetaBoard", "fields": [
+                        { "name": "id", "type": { "kind": "NON_NULL", "name": null,
+                            "ofType": { "kind": "SCALAR", "name": "Bytes", "ofType": null } } }
+                    ] },
+                    { "kind": "OBJECT", "name": "MetaV1_filter", "fields": [
+                        { "name": "id", "type": { "kind": "SCALAR", "name": "ID", "ofType": null } }
+                    ] },
+                    { "kind": "OBJECT", "name": "Query", "fields": [] },
+                    { "kind": "OBJECT", "name": "_Meta_", "fields": [] },
+                    { "kind": "SCALAR", "name": "Bytes", "fields": null }
+                ] } }
+            }));
+            })
+            .await;
+
+        let sdl = fetch_live_entities_as_sdl(&server.url("/")).await.unwrap();
+        assert!(sdl.contains("type MetaBoard @entity"));
+        assert!(sdl.contains("id: Bytes!"));
+        assert!(!sdl.contains("MetaV1_filter"));
+        assert!(!sdl.contains("Query"));
+        assert!(!sdl.contains("_Meta_"));
+    }
+
+    #[tokio::test]
+    async fn fetch_live_entities_propagates_graphql_errors() {
+        use httpmock::Method::POST;
+        use httpmock::MockServer;
+
+        let server = MockServer::start_async().await;
+        let _mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path("/");
+                then.status(200).json_body(serde_json::json!({
+                    "errors": [{ "message": "introspection disabled" }]
+                }));
+            })
+            .await;
+
+        let err = fetch_live_entities_as_sdl(&server.url("/"))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("introspection errors"));
+        assert!(err.to_string().contains("introspection disabled"));
+    }
+
+    #[tokio::test]
+    async fn fetch_live_entities_errors_on_malformed_response() {
+        use httpmock::Method::POST;
+        use httpmock::MockServer;
+
+        let server = MockServer::start_async().await;
+        let _mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path("/");
+                then.status(200)
+                    .json_body(serde_json::json!({ "data": {} }));
+            })
+            .await;
+
+        let err = fetch_live_entities_as_sdl(&server.url("/"))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("missing /data/__schema/types"));
+    }
+
+    #[tokio::test]
+    async fn fetch_live_entities_errors_on_http_failure() {
+        use httpmock::Method::POST;
+        use httpmock::MockServer;
+
+        let server = MockServer::start_async().await;
+        let _mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path("/");
+                then.status(500);
+            })
+            .await;
+
+        let err = fetch_live_entities_as_sdl(&server.url("/"))
+            .await
+            .unwrap_err();
+        // reqwest's error_for_status produces "500 Internal Server Error" text.
+        assert!(err.to_string().contains("500"));
+    }
+
+    // ---------- end-to-end CLI handler ----------
+
+    #[tokio::test]
+    async fn schema_check_reads_files_and_succeeds_on_match() {
+        use std::io::Write;
+        let mut src = tempfile::NamedTempFile::new().unwrap();
+        src.write_all(SOURCE_OK.as_bytes()).unwrap();
+        let mut con = tempfile::NamedTempFile::new().unwrap();
+        con.write_all(CONSUMER_OK.as_bytes()).unwrap();
+
+        schema_check(SchemaCheck {
+            source: Some(src.path().into()),
+            live_url: None,
+            consumer: con.path().into(),
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn schema_check_rejects_neither_source_nor_live_url() {
+        let mut con = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut con, CONSUMER_OK.as_bytes()).unwrap();
+
+        let err = schema_check(SchemaCheck {
+            source: None,
+            live_url: None,
+            consumer: con.path().into(),
+        })
+        .await
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("exactly one of --source or --live-url"));
+    }
+
+    #[tokio::test]
+    async fn schema_check_failure_includes_live_sdl_in_error() {
+        use httpmock::Method::POST;
+        use httpmock::MockServer;
+        use std::io::Write;
+
+        // Live introspection returns a single MetaBoard entity; consumer
+        // file omits it, so the error should include the live-derived SDL.
+        let server = MockServer::start_async().await;
+        let _mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path("/");
+                then.status(200).json_body(serde_json::json!({
+                    "data": { "__schema": { "types": [
+                        { "kind": "OBJECT", "name": "MetaBoard", "fields": [
+                            { "name": "id", "type": { "kind": "NON_NULL", "name": null,
+                                "ofType": { "kind": "SCALAR", "name": "Bytes", "ofType": null } } }
+                        ] }
+                    ] } }
+                }));
+            })
+            .await;
+
+        let mut con = tempfile::NamedTempFile::new().unwrap();
+        con.write_all(b"scalar X").unwrap();
+
+        let err = schema_check(SchemaCheck {
+            source: None,
+            live_url: Some(server.url("/")),
+            consumer: con.path().into(),
+        })
+        .await
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("entity `MetaBoard` is missing"));
+        assert!(msg.contains("Live introspection-derived entity SDL"));
+        assert!(msg.contains("type MetaBoard @entity"));
+    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,11 +1,11 @@
 #[cfg(feature = "tokio-full")]
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    rain_metadata::cli::main()
+    rain_metadata::cli::main().await
 }
 
 #[cfg(not(feature = "tokio-full"))]
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    rain_metadata::cli::main()
+    rain_metadata::cli::main().await
 }

--- a/crates/cli/src/meta/types/dotrain/source_v1.rs
+++ b/crates/cli/src/meta/types/dotrain/source_v1.rs
@@ -417,4 +417,29 @@ mod tests {
         // Verify the mock was called
         mock.assert();
     }
+
+    #[tokio::test]
+    async fn test_fetch_by_subject_sends_0x_prefixed_hex() {
+        // Pin the wire-format change made when MetaV1.subject migrated
+        // BigInt -> Bytes: the 32-byte subject must be sent as a hex
+        // string with a `0x` prefix so the GraphQL Bytes scalar accepts
+        // it. body_contains() makes the mock require the exact string,
+        // and mock.assert() panics if no request matched.
+        use httpmock::prelude::*;
+        let server = MockServer::start();
+        let mock_url = Url::parse(&server.url("/")).unwrap();
+
+        let subject = [0x42u8; 32];
+        let expected_hex = format!("0x{}", "42".repeat(32));
+
+        let mock = server.mock(|when, then| {
+            when.method(POST).path("/").body_contains(&expected_hex);
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({ "data": { "metaV1S": [] } }));
+        });
+
+        let _ = DotrainSourceV1::fetch_by_subject(subject, mock_url).await;
+        mock.assert();
+    }
 }

--- a/crates/cli/src/meta/types/dotrain/source_v1.rs
+++ b/crates/cli/src/meta/types/dotrain/source_v1.rs
@@ -4,7 +4,7 @@ use alloy::{
 };
 use rain_metaboard_subgraph::{
     metaboard_client::{MetaboardSubgraphClient, MetaboardSubgraphClientError},
-    types::metas::BigInt,
+    types::metas::Bytes,
 };
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -37,10 +37,10 @@ impl DotrainSourceV1 {
         subgraph_url: Url,
     ) -> Result<Option<Self>, Error> {
         let client = MetaboardSubgraphClient::new(subgraph_url);
-        let subject_hex = hex::encode(subject);
-        let subject_bigint = BigInt(subject_hex);
+        let subject_hex = format!("0x{}", hex::encode(subject));
+        let subject_bytes = Bytes(subject_hex);
 
-        match client.get_metabytes_by_subject(&subject_bigint).await {
+        match client.get_metabytes_by_subject(&subject_bytes).await {
             Ok(metabytes) => {
                 if metabytes.is_empty() {
                     return Ok(None);

--- a/crates/metaboard/src/metaboard_client.rs
+++ b/crates/metaboard/src/metaboard_client.rs
@@ -97,7 +97,7 @@ impl MetaboardSubgraphClient {
     /// Find all metas with a given subject
     pub async fn get_metabytes_by_subject(
         &self,
-        subject: &BigInt,
+        subject: &Bytes,
     ) -> Result<Vec<Vec<u8>>, MetaboardSubgraphClientError> {
         let data = self
             .query::<MetasBySubject, MetasBySubjectVariables>(MetasBySubjectVariables {
@@ -260,7 +260,7 @@ mod tests {
         let server = MockServer::start_async().await;
         let url = Url::parse(&server.url("/")).unwrap();
 
-        let subject = BigInt("123".to_string());
+        let subject = Bytes("0x7b".to_string());
 
         // Mock a successful response
         server.mock(|when, then| {
@@ -323,7 +323,7 @@ mod tests {
         });
 
         let client = MetaboardSubgraphClient::new(url);
-        let subject = BigInt("789".to_string());
+        let subject = Bytes("0x315".to_string());
 
         let result = client.get_metabytes_by_subject(&subject).await;
 

--- a/crates/metaboard/src/metaboard_client.rs
+++ b/crates/metaboard/src/metaboard_client.rs
@@ -262,9 +262,14 @@ mod tests {
 
         let subject = Bytes("0x7b".to_string());
 
-        // Mock a successful response
+        // Mock a successful response. body_contains pins the wire shape:
+        // the subject Bytes value must be sent verbatim in the request
+        // (not coerced to a number, not stripped of `0x`).
         server.mock(|when, then| {
-            when.method(POST).path("/").body_contains("subject");
+            when.method(POST)
+                .path("/")
+                .body_contains("subject")
+                .body_contains("0x7b");
             then.status(200).json_body_obj(&{
                 serde_json::json!({
                     "data": {

--- a/crates/metaboard/src/schema/metaboard.graphql
+++ b/crates/metaboard/src/schema/metaboard.graphql
@@ -80,11 +80,19 @@ enum MetaBoard_orderBy {
 
 type MetaV1 {
   id: ID!
+  transaction: Transaction!
   metaBoard: MetaBoard!
   sender: Bytes!
-  subject: BigInt!
+  subject: Bytes!
   metaHash: Bytes!
   meta: Bytes!
+}
+
+type Transaction {
+  id: Bytes!
+  timestamp: BigInt!
+  blockNumber: BigInt!
+  from: Bytes!
 }
 
 input MetaV1_filter {

--- a/crates/metaboard/src/schema/metaboard.graphql
+++ b/crates/metaboard/src/schema/metaboard.graphql
@@ -135,14 +135,16 @@ input MetaV1_filter {
   sender_not_in: [Bytes!]
   sender_contains: Bytes
   sender_not_contains: Bytes
-  subject: BigInt
-  subject_not: BigInt
-  subject_gt: BigInt
-  subject_lt: BigInt
-  subject_gte: BigInt
-  subject_lte: BigInt
-  subject_in: [BigInt!]
-  subject_not_in: [BigInt!]
+  subject: Bytes
+  subject_not: Bytes
+  subject_gt: Bytes
+  subject_lt: Bytes
+  subject_gte: Bytes
+  subject_lte: Bytes
+  subject_in: [Bytes!]
+  subject_not_in: [Bytes!]
+  subject_contains: Bytes
+  subject_not_contains: Bytes
   metaHash: Bytes
   metaHash_not: Bytes
   metaHash_gt: Bytes

--- a/crates/metaboard/src/types/metas.rs
+++ b/crates/metaboard/src/types/metas.rs
@@ -13,7 +13,7 @@ pub struct MetasByHash {
 
 #[derive(cynic::QueryVariables, Debug)]
 pub struct MetasBySubjectVariables {
-    pub subject: Option<BigInt>,
+    pub subject: Option<Bytes>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
@@ -43,7 +43,7 @@ pub struct MetaV1 {
     pub sender: Bytes,
     pub id: cynic::Id,
     pub meta_board: MetaBoard,
-    pub subject: BigInt,
+    pub subject: Bytes,
 }
 
 #[derive(cynic::QueryFragment, Debug)]


### PR DESCRIPTION
## Summary

Adds \`rain-metadata schema-check\` subcommand that compares the source subgraph schema (\`subgraph/schema.graphql\`) to the consumer crate's introspection snapshot (\`crates/metaboard/src/schema/metaboard.graphql\`) at the entity level: missing entities, missing fields, field-type mismatches. Exits non-zero on drift.

Wired in as a pre-deploy step in \`manual-subgraph-deploy.yml\`. If drift is detected, the workflow fails before \`subgraph-deploy\` runs — no Goldsky deploys, nothing to roll back.

## Demonstration

Run on this branch surfaces real drift between the deployed subgraph and the metaboard crate's snapshot:

\`\`\`
schema check failed with 3 mismatches:
  - field \`MetaV1.transaction\` is missing from consumer schema
  - field \`MetaV1.subject\` type mismatch: source \`Bytes!\` vs consumer \`BigInt!\`
  - entity \`Transaction\` is missing from consumer schema
\`\`\`

Smoke-tested end-to-end: triggered \`Subgraph manual deploy\` on this branch ([run 25311954053](https://github.com/rainlanguage/rain.metadata/actions/runs/25311954053)). Schema-check step failed; \`subgraph-deploy\` step was skipped. Zero Goldsky deploys.

## Closes

This PR adds the gate. It will block all further deploys until \`crates/metaboard/src/schema/metaboard.graphql\` is regenerated to match the live subgraph. Closes #58 on merge + snapshot regeneration.

## Test plan
- [x] \`cargo test -p rain-metadata\` — 5 new tests covering matching, missing entity, missing field, type mismatch, and the real divergence
- [x] Pre-deploy step verified to fail and skip deploy on this branch
- [ ] CI green (Rainix CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to validate GraphQL consumer schemas from a local file or a live endpoint.
  * Deployment flow now captures deployed endpoints, runs post-deploy schema validation, and rolls back deployments on validation failures.

* **Schema**
  * MetaV1 now includes a non-null transaction field; subject type changed to Bytes; new Transaction type added.

* **Tests**
  * Comprehensive unit tests for schema validation success and multiple mismatch scenarios.

* **Chores**
  * Added a GraphQL parser dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->