### PR TITLE
fix(soldeer): exclude .envrc and .cargo from publish zip

### DIFF
--- a/.soldeerignore
+++ b/.soldeerignore
@@ -1,5 +1,7 @@
 .DS_Store
+.cargo
 .coderabbit.yaml
+.envrc
 .gas-snapshot
 .git
 .github


### PR DESCRIPTION
Soldeer's sensitive-files prompt flagged `.envrc` when publishing v0.1.0 — workflow exits with `error during IO operation: not connected` in non-interactive CI. Add `.envrc` and `.cargo` to .soldeerignore.

After merge: drop the v0.1.0 tag (publish never succeeded) and re-tag v0.1.0 to retrigger publish, or tag v0.1.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to ignore additional top-level entries.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rain.metadata/pull/110)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->