### PR TITLE
fix(soldeer): exclude /crates and /subgraph from publish zip

### DIFF
--- a/.soldeerignore
+++ b/.soldeerignore
@@ -13,7 +13,9 @@
 CLAUDE.md
 /audit
 /cache
+/crates
 /dependencies
+/subgraph
 /flake.lock
 /flake.nix
 /foundry.lock


### PR DESCRIPTION
Soldeer's sensitive-files check (`check_dotfiles`) flags any path with a component starting with a period — including dotfiles deep inside the tree. `crates/cli/.rustfmt.toml`, `subgraph/.prettierignore`, and `subgraph/tests/.bin/metaboard.wasm` were leaking into the published zip. Neither `crates/` (the rust workspace) nor `subgraph/` (the indexer) belongs in the soldeer package.

After merge: re-move the v0.1.0 tag.