### PR TITLE
chore: release rain-metadata crates 0.1.0

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rain-metadata"
-version = "0.0.2-alpha.6"
+version = "0.1.0"
 edition = "2021"
 description = "Tooling and utilities for RainLanguage metadata."
 license = "LicenseRef-DCL-1.0"
@@ -37,8 +37,8 @@ reqwest = { version = "0.11.22", features = ["json"] }
 alloy = { version = "1.0.9", features = ["rand", "json", "json-abi"] }
 graphql_client = "0.13.0"
 graphql-parser = { version = "0.4", optional = true }
-rain-metaboard-subgraph = { path = "../metaboard" }
-rain-metadata-bindings = { path = "../bindings" }
+rain-metaboard-subgraph = { path = "../metaboard", version = "0.1.0" }
+rain-metadata-bindings = { path = "../bindings", version = "0.1.0" }
 thiserror = "1.0.56"
 alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "f7b5bfd0687f16c77dbfdd4905b2434793fa7885" }
 url = "2.5.0"


### PR DESCRIPTION
## Summary

- Bumps \`rain-metadata\` from \`0.0.2-alpha.6\` → \`0.1.0\` (first stable).
- \`rain-metadata-bindings\` and \`rain-metaboard-subgraph\` stay at \`0.1.0\` (their tree version) — first crates.io publishes.
- Adds explicit \`version = \"0.1.0\"\` next to the \`path = ...\` lines in the cli crate so \`cargo publish\` resolves the internal deps from crates.io rather than failing on path-only entries.

Resolves #115.

## Test plan

- [ ] CI green.
- [ ] After merge, publish in order: \`rain-metadata-bindings\` → \`rain-metaboard-subgraph\` → \`rain-metadata\`.