### PR TITLE
chore: sync Cargo.lock to rain-metadata 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3649,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "rain-metadata"
-version = "0.0.2-alpha.6"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "alloy-ethers-typecast",


### PR DESCRIPTION
Lockfile still pinned to 0.0.2-alpha.6 after #116 — caused the manual-rs-release workflow to fail at `cargo release` with 'uncommitted changes detected'.

Tracks #115.