### PR TITLE
refactor(cli): drop alloy-ethers-typecast for alloy Provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,26 +223,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-ethers-typecast"
-version = "0.2.0"
-source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=f7b5bfd0687f16c77dbfdd4905b2434793fa7885#f7b5bfd0687f16c77dbfdd4905b2434793fa7885"
-dependencies = [
- "alloy",
- "async-trait",
- "derive_builder",
- "getrandom 0.3.3",
- "once_cell",
- "rain-error-decoding",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tracing",
- "tracing-subscriber",
- "url",
-]
-
-[[package]]
 name = "alloy-genesis"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1537,7 +1517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728467a89a305811848807cbf2bf23d421c1e99052bf7700d08b17dd7b846a28"
 dependencies = [
  "cynic-parser",
- "darling 0.20.11",
+ "darling",
  "once_cell",
  "ouroboros",
  "proc-macro2",
@@ -1565,19 +1545,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8069a1fd8d13d09c56d22ec4096329ee5735d0296ac78b7a7c30a9c76537f4ba"
 dependencies = [
  "cynic-codegen",
- "darling 0.20.11",
+ "darling",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
 ]
 
 [[package]]
@@ -1586,22 +1556,8 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1620,22 +1576,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core 0.14.4",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core 0.20.11",
+ "darling_core",
  "quote",
  "syn 2.0.101",
 ]
@@ -1691,37 +1636,6 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
-dependencies = [
- "darling 0.14.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
-dependencies = [
- "derive_builder_core",
  "syn 1.0.109",
 ]
 
@@ -3609,25 +3523,13 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rain-erc"
-version = "0.0.0"
-source = "git+https://github.com/rainlanguage/rain.erc?rev=7b0f382f5e0788b0173c2391e09f4411f1c38300#7b0f382f5e0788b0173c2391e09f4411f1c38300"
-dependencies = [
- "alloy",
- "alloy-ethers-typecast",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "rain-error-decoding"
-version = "0.1.0"
-source = "git+https://github.com/rainlanguage/rain.error?rev=bf08b5ab305287fc49408a441d6375f35dc280db#bf08b5ab305287fc49408a441d6375f35dc280db"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c1743f958ef5d54d361f3b7e2ff9109adfe0549934c46fac729f8d69ec09677"
 dependencies = [
  "alloy",
  "getrandom 0.2.16",
- "once_cell",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
+ "getrandom 0.3.3",
  "thiserror 1.0.69",
 ]
 
@@ -3652,7 +3554,6 @@ name = "rain-metadata"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "alloy-ethers-typecast",
  "anyhow",
  "clap",
  "deflate",
@@ -4330,7 +4231,7 @@ version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.101",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -40,9 +40,8 @@ graphql-parser = { version = "0.4", optional = true }
 rain-metaboard-subgraph = { path = "../metaboard", version = "0.1.2" }
 rain-metadata-bindings = { path = "../bindings", version = "0.1.4" }
 thiserror = "1.0.56"
-alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "f7b5bfd0687f16c77dbfdd4905b2434793fa7885" }
 url = "2.5.0"
-rain-erc = { git = "https://github.com/rainlanguage/rain.erc", rev = "7b0f382f5e0788b0173c2391e09f4411f1c38300" }
+rain-erc = "0.1"
 
 # json-schema
 schemars = { version = "0.8.12", optional = true }

--- a/crates/cli/src/meta/mod.rs
+++ b/crates/cli/src/meta/mod.rs
@@ -11,7 +11,9 @@ use std::{collections::HashMap, convert::TryFrom, fmt::Debug, sync::Arc};
 use strum::{EnumIter, EnumString};
 use types::authoring::v1::AuthoringMeta;
 use alloy::sol_types::private::Address;
-use alloy_ethers_typecast::transaction::{ReadContractParameters, ReadableClient};
+use alloy::providers::Provider;
+use alloy::rpc::types::TransactionRequest;
+use alloy::sol_types::SolCall;
 use rain_erc::erc165::{IERC165, XorSelectors, supports_erc165};
 
 pub mod magic;
@@ -421,11 +423,14 @@ pub async fn search_deployer(
 }
 
 /// checks if the given contract implements IDescribeByMetaV1 interface
-pub async fn implements_i_described_by_meta_v1(
-    client: &ReadableClient,
+pub async fn implements_i_described_by_meta_v1<P: Provider>(
+    provider: &P,
     contract_address: Address,
 ) -> bool {
-    if !supports_erc165(client, contract_address).await {
+    if !supports_erc165(provider, contract_address)
+        .await
+        .unwrap_or(false)
+    {
         return false;
     }
 
@@ -434,15 +439,16 @@ pub async fn implements_i_described_by_meta_v1(
         return false;
     }
 
-    let parameters = ReadContractParameters {
-        address: contract_address,
-        call: IERC165::supportsInterfaceCall {
-            interfaceID: interface_id_res.unwrap().into(),
-        },
-        block_number: None,
-        gas: None,
+    let call = IERC165::supportsInterfaceCall {
+        interfaceID: interface_id_res.unwrap().into(),
     };
-    client.read(parameters).await.unwrap_or(false)
+    let tx = TransactionRequest::default()
+        .to(contract_address)
+        .input(call.abi_encode().into());
+    match provider.call(tx).await {
+        Ok(bytes) => IERC165::supportsInterfaceCall::abi_decode_returns(&bytes).unwrap_or(false),
+        Err(_) => false,
+    }
 }
 
 /// All required NPE2 ExpressionDeployer data for reproducing it on a local evm
@@ -920,7 +926,7 @@ mod tests {
         *, bytes32_to_str, magic::KnownMagic, str_to_bytes32, types::authoring::v1::AuthoringMeta,
         ContentEncoding, ContentLanguage, ContentType, Error, RainMetaDocumentV1Item,
     };
-    use alloy_ethers_typecast::transaction::ReadableClient;
+    use alloy::providers::ProviderBuilder;
     use alloy::{providers::mock::Asserter, rpc::json_rpc::ErrorPayload, sol_types::SolType};
     use serde_json::json;
 
@@ -1268,9 +1274,9 @@ mod tests {
     #[tokio::test]
     async fn test_implements_i_describe_by_meta_v1() {
         // makes new server/client with success response for erc165 check
-        async fn new_server_client() -> (Asserter, ReadableClient) {
+        async fn new_server_client() -> (Asserter, impl Provider) {
             let asserter = Asserter::new();
-            let client = ReadableClient::new_mocked(asserter.clone());
+            let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
 
             // Mock a responses for successful supports erc165 check
             asserter.push_success(
@@ -1280,33 +1286,33 @@ mod tests {
                 &"0x0000000000000000000000000000000000000000000000000000000000000000",
             );
 
-            (asserter, client)
+            (asserter, provider)
         }
 
         let address = Address::random();
 
         // mock a true response for implements IDescribedByMetaV1
-        let (asserter, client) = new_server_client().await;
+        let (asserter, provider) = new_server_client().await;
         asserter
             .push_success(&"0x0000000000000000000000000000000000000000000000000000000000000001");
-        let result = implements_i_described_by_meta_v1(&client, address).await;
+        let result = implements_i_described_by_meta_v1(&provider, address).await;
         assert!(result);
 
         // mock a false response for implements IDescribedByMetaV1
-        let (asserter, client) = new_server_client().await;
+        let (asserter, provider) = new_server_client().await;
         asserter
             .push_success(&"0x0000000000000000000000000000000000000000000000000000000000000000");
-        let result = implements_i_described_by_meta_v1(&client, address).await;
+        let result = implements_i_described_by_meta_v1(&provider, address).await;
         assert!(!result);
 
         // mock a revert response for implements IDescribedByMetaV1
-        let (asserter, client) = new_server_client().await;
+        let (asserter, provider) = new_server_client().await;
         asserter.push_failure(ErrorPayload {
             code: -32003,
             message: "execution reverted".into(),
             data: Some(serde_json::value::to_raw_value(&json!("0x00")).unwrap()),
         });
-        let result = implements_i_described_by_meta_v1(&client, address).await;
+        let result = implements_i_described_by_meta_v1(&provider, address).await;
         assert!(!result);
     }
 }

--- a/crates/cli/src/meta/types/authoring/v2.rs
+++ b/crates/cli/src/meta/types/authoring/v2.rs
@@ -1,8 +1,8 @@
 use alloy::{primitives::FixedBytes, sol_types::SolType};
-use alloy_ethers_typecast::transaction::{
-    ReadContractParametersBuilder, ReadContractParametersBuilderError, ReadableClient,
-    ReadableClientError,
-};
+use alloy::providers::{Provider, ProviderBuilder};
+use alloy::rpc::types::TransactionRequest;
+use alloy::sol_types::SolCall;
+use alloy::transports::{RpcError, TransportErrorKind};
 use alloy::primitives::hex::FromHexError;
 use alloy::sol_types::private::Address;
 use alloy::sol;
@@ -50,9 +50,7 @@ pub enum AuthoringMetaV2Error {
     #[error(transparent)]
     UrlParseError(#[from] url::ParseError),
     #[error(transparent)]
-    ReadableClientError(#[from] ReadableClientError),
-    #[error(transparent)]
-    ReadContractParametersError(#[from] ReadContractParametersBuilderError),
+    RpcError(#[from] RpcError<TransportErrorKind>),
     #[error(transparent)]
     MetaboardSubgraphError(
         #[from] rain_metaboard_subgraph::metaboard_client::MetaboardSubgraphClientError,
@@ -67,6 +65,8 @@ pub enum AuthoringMetaV2Error {
     MetaError(#[from] crate::error::Error),
     #[error("Contract has no words")]
     HasNoWords,
+    #[error("no RPC URLs provided")]
+    NoRpcs,
 }
 
 #[derive(Error, Debug)]
@@ -126,18 +126,27 @@ impl AuthoringMetaV2 {
         rpcs: Vec<String>,
         metaboard_url: String,
     ) -> Result<Self, FetchAuthoringMetaV2WordError> {
-        // get the metahash
-        let client = ReadableClient::new_from_http_urls(rpcs.clone()).map_err(|error| {
-            FetchAuthoringMetaV2WordError {
+        // build a read provider over the first RPC
+        let url = rpcs
+            .first()
+            .cloned()
+            .ok_or_else(|| FetchAuthoringMetaV2WordError {
+                contract_address,
+                rpcs: rpcs.clone(),
+                metaboard_url: metaboard_url.clone(),
+                error: AuthoringMetaV2Error::NoRpcs,
+            })?
+            .parse()
+            .map_err(|error: url::ParseError| FetchAuthoringMetaV2WordError {
                 contract_address,
                 rpcs: rpcs.clone(),
                 metaboard_url: metaboard_url.clone(),
                 error: error.into(),
-            }
-        })?;
+            })?;
+        let provider = ProviderBuilder::new().connect_http(url);
 
         // return "has no words" error if the contract does not implement IDescribeByMetaV2 interface
-        if !implements_i_described_by_meta_v1(&client, contract_address).await {
+        if !implements_i_described_by_meta_v1(&provider, contract_address).await {
             return Err(FetchAuthoringMetaV2WordError {
                 contract_address,
                 rpcs: rpcs.clone(),
@@ -146,27 +155,28 @@ impl AuthoringMetaV2 {
             });
         }
 
-        let parameters = ReadContractParametersBuilder::default()
-            .address(contract_address)
-            .call(IDescribedByMetaV1::describedByMetaV1Call {})
-            .build()
+        let call = IDescribedByMetaV1::describedByMetaV1Call {};
+        let tx = TransactionRequest::default()
+            .to(contract_address)
+            .input(call.abi_encode().into());
+        let bytes = provider
+            .call(tx)
+            .await
             .map_err(|error| FetchAuthoringMetaV2WordError {
                 contract_address,
                 rpcs: rpcs.clone(),
                 metaboard_url: metaboard_url.clone(),
                 error: error.into(),
             })?;
-
-        let FixedBytes(metahash) =
-            client
-                .read(parameters)
-                .await
-                .map_err(|error| FetchAuthoringMetaV2WordError {
-                    contract_address,
-                    rpcs: rpcs.clone(),
-                    metaboard_url: metaboard_url.clone(),
-                    error: error.into(),
-                })?;
+        let FixedBytes(metahash) = IDescribedByMetaV1::describedByMetaV1Call::abi_decode_returns(
+            &bytes,
+        )
+        .map_err(|error| FetchAuthoringMetaV2WordError {
+            contract_address,
+            rpcs: rpcs.clone(),
+            metaboard_url: metaboard_url.clone(),
+            error: error.into(),
+        })?;
 
         // query the metaboard for the metas
         let subgraph_client = MetaboardSubgraphClient::new(metaboard_url.parse().map_err(


### PR DESCRIPTION
Removes the `alloy-ethers-typecast` git dependency from the `rain-metadata` cli — the last blocker to publishing the cli to crates.io (#121).

- `ReadableClient` / `ReadContractParameters(Builder)` → alloy `Provider` + `eth_call` (`TransactionRequest` + `SolCall::abi_decode_returns`), same pattern as the interpreter parser (rainlang#511).
- `rain-erc` git dep → crates.io `0.1` (its `supports_erc165` is now `Provider`-based).
- `implements_i_described_by_meta_v1` is generic over `Provider`; `fetch_for_contract` builds a provider from the first RPC.
- Tests use alloy `connect_mocked_client` instead of `ReadableClient::new_mocked`.

All 120 cli lib tests pass; no `alloy_ethers_typecast` references remain.

Note: `fetch_for_contract` now reads from the first RPC rather than ReadableClient's multi-RPC fallback — fine for the cli; a fallback provider can be added later if needed.

Closes #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)