### PR TITLE
copy-artifacts: use shared rainix reusable + fix stale CLAUDE.md deps

### DIFF
--- a/.github/workflows/copy-artifacts.yaml
+++ b/.github/workflows/copy-artifacts.yaml
@@ -2,30 +2,8 @@ name: copy-artifacts
 on: [push]
 jobs:
   copy-artifacts:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: nixbuild/nix-quick-install-action@v30
-        with:
-          nix_conf: |
-            keep-env-derivations = true
-            keep-outputs = true
-      - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v7
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 1G
-      - name: Install soldeer dependencies
-        if: hashFiles('soldeer.lock') != ''
-        run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
-      - name: Build solidity artifacts
-        run: nix develop github:rainlanguage/rainix#sol-shell -c forge build
-      - name: Copy forge artifacts into committed location
-        run: nix develop github:rainlanguage/rainix#sol-shell -c forge script ./script/CopyArtifacts.sol
-      - name: Assert committed artifacts match freshly built
-        run: |
-          if ! git diff --exit-code; then
-            echo "::error::Committed artifacts in crates/bindings/abi/ are stale. Run 'forge script script/CopyArtifacts.sol' and commit the updated files."
-            exit 1
-          fi
+    # Shared reusable (rainix#201): build from committed sources and assert the
+    # committed abi artifacts are still current. Includes Cachix substitution +
+    # 8G GC cap. secrets: inherit carries CACHIX_AUTH_TOKEN.
+    uses: rainlanguage/rainix/.github/workflows/rainix-copy-artifacts.yaml@main
+    secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,10 @@ cargo test test_name
   `bytecode_hash = "none"`, `cbor_metadata = false`
 - **Rust workspace**: `Cargo.toml` at root, three crates
 - **Fuzz runs**: 5,096 (foundry.toml `[fuzz]`)
-- **Remappings**: `rain.deploy/=lib/rain.deploy/src/`
+- **Dependencies**: managed by [Soldeer](https://soldeer.xyz) (`[dependencies]`
+  in `foundry.toml`, `libs = ["dependencies"]`), not git submodules; remappings
+  point into `dependencies/` (e.g.
+  `rain-deploy-0.1.2/=dependencies/rain-deploy-0.1.2/`)
 
 ## Licensing
 


### PR DESCRIPTION
Replace the local `copy-artifacts.yaml` with a thin caller of `rainix-copy-artifacts.yaml` (rainlanguage/rainix#201) — centralizes build-and-assert-clean + the Cachix/GC-cap resilience. No BuildPointers.sol here, so that step is skipped; CopyArtifacts.sol doesn't use ffi so the reusable's `--ffi` is a no-op.

Also fixes the stale CLAUDE.md remapping (`lib/rain.deploy`) — the repo is on Soldeer (`dependencies/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)