### PR TITLE
chore: latest rainix + soldeer re-lock

### DIFF
--- a/.github/workflows/manual-rs-release.yml
+++ b/.github/workflows/manual-rs-release.yml
@@ -29,8 +29,7 @@ jobs:
           git config --global user.name "${{ secrets.CI_GIT_USER }}"
       - name: Install soldeer dependencies
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
-      - run: nix develop --command rainix-sol-prelude
-      - run: nix develop --command rainix-rs-prelude
-      - run: nix develop --command cargo release --no-confirm --execute alpha
+      - run: nix develop github:rainlanguage/rainix#sol-shell -c forge build
+      - run: nix develop github:rainlanguage/rainix#rust-shell -c cargo release --no-confirm --execute alpha
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         "solc": "solc"
       },
       "locked": {
-        "lastModified": 1779528129,
-        "narHash": "sha256-nz3IUGR+NXpWtSz4KUTQ+08sVam+BNBJZKvNltBCWGs=",
+        "lastModified": 1780287289,
+        "narHash": "sha256-eZ74zj6VwotSmT1kXImwA2yX0el0pZthcgNjg7j/AyQ=",
         "owner": "rainlanguage",
         "repo": "rainix",
-        "rev": "a7d0bb0e5ad973d0bcd3446399ed62475353afee",
+        "rev": "f22d4dcaca61717e33eac65e7b09b9a82f604c1f",
         "type": "github"
       },
       "original": {

--- a/foundry.toml
+++ b/foundry.toml
@@ -28,7 +28,7 @@ runs = 5096
 
 [dependencies]
 forge-std = "1.16.1"
-"rain-deploy" = "0.1.2"
+"rain-deploy" = "0.1.3"
 
 [soldeer]
 recursive_deps = false

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -4,7 +4,7 @@ pragma solidity =0.8.25;
 
 import {Script} from "forge-std-1.16.1/src/Script.sol";
 import {MetaBoard} from "src/concrete/MetaBoard.sol";
-import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.3/src/lib/LibRainDeploy.sol";
 import {LibMetaBoardDeploy} from "src/lib/deploy/LibMetaBoardDeploy.sol";
 
 /// @title Deploy

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -7,7 +7,7 @@ integrity = "60e55d10150354ca4a1e2985c5456c834b92b82ef85ab0e1d92a7786cddbd219"
 
 [[dependencies]]
 name = "rain-deploy"
-version = "0.1.2"
-url = "https://soldeer-revisions.s3.amazonaws.com/rain-deploy/0_1_2_09-05-2026_19:49:20_rain.zip"
-checksum = "94d3daf2f9f90062d2e676077c2b4ccd2bdd66201665a2209e98016e155f619a"
+version = "0.1.3"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-deploy/0_1_3_20-05-2026_13:02:35_rain.zip"
+checksum = "6e9a7a1562ee2766a1cc3a4a077b853ec628a3070b282e6e9102a252f2a6a5b5"
 integrity = "10bff708d9e5d8b77655b8a8fc0c755cef8e3fc876cc3ff100425d27b08294a0"

--- a/test/lib/deploy/LibMetaBoardDeploy.t.sol
+++ b/test/lib/deploy/LibMetaBoardDeploy.t.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.3/src/lib/LibRainDeploy.sol";
 import {LibMetaBoardDeploy} from "src/lib/deploy/LibMetaBoardDeploy.sol";
 import {MetaBoard} from "src/concrete/MetaBoard.sol";
 


### PR DESCRIPTION
Bumps rainix to latest and re-locks soldeer deps.

- `rainix.url` -> `github:rainlanguage/rainix`, `nix flake update rainix`
- soldeer deps bumped to latest registry versions where behind, then re-locked
- verified via `nix develop` (latest rainix dev shell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)