### PR TITLE
ci: add soldeer to rainix-autopublish, drop manual publish-soldeer

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -12,4 +12,5 @@ jobs:
     uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
     with:
       crates: rain-metadata-bindings rain-metaboard-subgraph rain-metadata
+      soldeer-package: rain-metadata
     secrets: inherit

--- a/.github/workflows/publish-soldeer.yaml
+++ b/.github/workflows/publish-soldeer.yaml
@@ -1,8 +1,0 @@
-name: Publish to Soldeer
-on:
-  push:
-    tags: ["v*"]
-jobs:
-  publish:
-    uses: rainlanguage/rainix/.github/workflows/publish-soldeer.yaml@main
-    secrets: inherit

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,3 +1,7 @@
+[package]
+name = "rain-metadata"
+version = "0.1.0"
+
 [profile.default]
 
 solc = "0.8.25"


### PR DESCRIPTION
Part of removing the manual `publish-soldeer` reusable from rainix. Adds `soldeer-package: rain-metadata` to the existing `package-release.yaml` (rainix-autopublish) and `[package].version = 0.1.0` (current registry release) to foundry.toml; deletes the tag-driven `publish-soldeer.yaml`. No publish fires from this PR.