### PR TITLE
test: one contract per file (satisfy rainix single-contract gate)

### DIFF
--- a/test/lib/LibDescribedByMeta.emitForDescribedAddress.t.sol
+++ b/test/lib/LibDescribedByMeta.emitForDescribedAddress.t.sol
@@ -8,18 +8,7 @@ import {IDescribedByMetaV1} from "src/interface/IDescribedByMetaV1.sol";
 import {IMetaBoardV1_2} from "src/interface/unstable/IMetaBoardV1_2.sol";
 import {MetaBoard} from "src/concrete/MetaBoard.sol";
 import {META_MAGIC_NUMBER_V1} from "src/interface/unstable/IMetaV1_2.sol";
-
-contract TestDescribedByMetaV1 is IDescribedByMetaV1 {
-    bytes32 public immutable EXPECTED;
-
-    constructor(bytes memory meta) {
-        EXPECTED = keccak256(meta);
-    }
-
-    function describedByMetaV1() external view override returns (bytes32) {
-        return EXPECTED;
-    }
-}
+import {TestDescribedByMetaV1} from "test/lib/TestDescribedByMetaV1.sol";
 
 contract LibDescribedByMetaEmitForDescribedAddressTest is Test {
     function externalEmitForDescribedAddress(IMetaBoardV1_2 metaboard, IDescribedByMetaV1 described, bytes memory meta)

--- a/test/lib/TestDescribedByMetaV1.sol
+++ b/test/lib/TestDescribedByMetaV1.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IDescribedByMetaV1} from "src/interface/IDescribedByMetaV1.sol";
+
+/// @dev Test implementation of `IDescribedByMetaV1` that reports the keccak256
+/// hash of the metadata bytes provided to its constructor.
+contract TestDescribedByMetaV1 is IDescribedByMetaV1 {
+    bytes32 public immutable EXPECTED;
+
+    constructor(bytes memory meta) {
+        EXPECTED = keccak256(meta);
+    }
+
+    function describedByMetaV1() external view override returns (bytes32) {
+        return EXPECTED;
+    }
+}


### PR DESCRIPTION
The rainix `rainix-sol-single-contract` gate (added in rainlanguage/rainix#214) is failing on `main` because a test `.sol` file declares more than one contract. This greens `main` and unblocks #128.

The gate's authoritative output flagged a single violation:

```
ERROR: test/lib/LibDescribedByMeta.emitForDescribedAddress.t.sol declares 2 contracts; Rain convention is one contract per file.
```

## Files split

- `test/lib/LibDescribedByMeta.emitForDescribedAddress.t.sol` (was 2 contracts) -> keeps the primary test contract `LibDescribedByMetaEmitForDescribedAddressTest`; the `TestDescribedByMetaV1` mock is moved to the new file `test/lib/TestDescribedByMetaV1.sol`. The original file now imports the moved mock so all references resolve.

This is a pure file reorganization: no test logic or contract code changed.

## Verification (rainix sol-shell)

- `rainix-sol-single-contract` exits 0 (no violations remain).
- `forge build` clean.
- `forge fmt --check` clean.
- `forge test` for the split contract: 2 passed, 0 failed (5096 fuzz runs each). The only failures in the full suite are pre-existing and environment-gated (missing `*_RPC_URL` env vars and the `yq` binary), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)